### PR TITLE
[Server #11] 퀴즈 정답 확인 로직 구현

### DIFF
--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -9,6 +9,7 @@ import { QuestionModule } from './question/question.module';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 import { PortfolioModule } from './portfolio/portfolio.module';
+import { ResultModule } from './result/result.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { PortfolioModule } from './portfolio/portfolio.module';
     QuestionModule,
     AuthModule,
     PortfolioModule,
+    ResultModule,
   ],
 })
 export class AppModule implements NestModule {

--- a/apps/server/src/question/entities/question.entity.ts
+++ b/apps/server/src/question/entities/question.entity.ts
@@ -1,6 +1,13 @@
 import { BaseEntity } from 'src/common/entity/base.entity';
 import { QuizEntity } from 'src/quiz/entities/quiz.entity';
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { ResultEntity } from 'src/result/entities/result.entity';
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 
 @Entity('question')
 export class QuestionEntity extends BaseEntity {
@@ -18,4 +25,7 @@ export class QuestionEntity extends BaseEntity {
 
   @ManyToOne(() => QuizEntity, (quiz) => quiz.id)
   quiz: QuizEntity; // quizId 생성
+
+  @OneToOne(() => ResultEntity, (result) => result.id)
+  result: ResultEntity;
 }

--- a/apps/server/src/question/question.service.ts
+++ b/apps/server/src/question/question.service.ts
@@ -79,7 +79,7 @@ export class QuestionService {
     - Category: ${category}
     - Details: ${details.join(', ')}
     - Difficulty Level: ${level}
-    - Number of questions: 1
+    - Number of questions: ${numQuestions}
     - Types of questions: Mix of multiple choice, short answer, and essay questions.
 
     The response should be in JSON format, and all answers should be in Korean, even though the request is in English.

--- a/apps/server/src/quiz/quiz.controller.ts
+++ b/apps/server/src/quiz/quiz.controller.ts
@@ -1,6 +1,13 @@
 import { CreateQuizDto } from './dto/create-quiz.dto';
 import { QuizService } from './quiz.service';
-import { Controller, Post, Body } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  Get,
+  Param,
+  ParseIntPipe,
+} from '@nestjs/common';
 
 @Controller('quiz')
 export class QuizController {
@@ -9,5 +16,10 @@ export class QuizController {
   @Post()
   async create(@Body() createQuizDto: CreateQuizDto) {
     return await this.quizService.create(createQuizDto);
+  }
+
+  @Get(':id')
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.quizService.findOne(id);
   }
 }

--- a/apps/server/src/quiz/quiz.service.ts
+++ b/apps/server/src/quiz/quiz.service.ts
@@ -16,21 +16,18 @@ export class QuizService {
   async create(createQuizDto: CreateQuizDto) {
     const { category, details, level } = createQuizDto;
 
-    // QuizEntity 저장
     const savedQuiz = await this.quizRepository.save({
       category,
       details: details.join(', '),
       level,
     });
 
-    // Quiz 문제 생성 요청
     const generatedQuestions = await this.questionService.create({
       category,
       details,
       level,
     });
 
-    // 생성된 Questions를 DB에 저장
     const questions = generatedQuestions.data.quizzes.map((questionData) => ({
       ...questionData,
       quiz: savedQuiz,
@@ -47,5 +44,12 @@ export class QuizService {
       message: '퀴즈와 문제를 성공적으로 생성했습니다.',
       data: finalQuiz,
     };
+  }
+
+  findOne(id: number) {
+    return this.quizRepository.findOne({
+      where: { id },
+      relations: ['questions'],
+    });
   }
 }

--- a/apps/server/src/result/dto/create-result.dto.ts
+++ b/apps/server/src/result/dto/create-result.dto.ts
@@ -1,4 +1,10 @@
-import { IsArray, IsNumber, IsString, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class CreateResultDto {
@@ -10,8 +16,10 @@ export class CreateResultDto {
 
 class UserAnswerDto {
   @IsNumber()
+  @IsNotEmpty()
   questionId: number;
 
   @IsString()
+  @IsNotEmpty()
   userAnswer: string;
 }

--- a/apps/server/src/result/dto/create-result.dto.ts
+++ b/apps/server/src/result/dto/create-result.dto.ts
@@ -1,0 +1,17 @@
+import { IsArray, IsNumber, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateResultDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UserAnswerDto)
+  answers: UserAnswerDto[];
+}
+
+class UserAnswerDto {
+  @IsNumber()
+  questionId: number;
+
+  @IsString()
+  userAnswer: string;
+}

--- a/apps/server/src/result/entities/result.entity.ts
+++ b/apps/server/src/result/entities/result.entity.ts
@@ -26,7 +26,10 @@ export class ResultEntity extends BaseEntity {
   @Column()
   correctAnswer: string;
 
-  @OneToOne(() => QuestionEntity, (question) => question.id)
+  @OneToOne(() => QuestionEntity, (question) => question.id, {
+    cascade: true,
+    nullable: false,
+  })
   @JoinColumn()
   question: QuestionEntity; // questionId 생성
 }

--- a/apps/server/src/result/entities/result.entity.ts
+++ b/apps/server/src/result/entities/result.entity.ts
@@ -1,4 +1,5 @@
 import { BaseEntity } from 'src/common/entity/base.entity';
+import { QuestionEntity } from 'src/question/entities/question.entity';
 import { QuizEntity } from 'src/quiz/entities/quiz.entity';
 import {
   Column,
@@ -14,10 +15,10 @@ export class ResultEntity extends BaseEntity {
   id: number;
 
   @Column()
-  answer: string;
+  userAnswer: string;
 
   @Column()
-  result: boolean;
+  isCorrect: boolean;
 
   @Column()
   description: string;
@@ -25,7 +26,7 @@ export class ResultEntity extends BaseEntity {
   @Column()
   correctAnswer: string;
 
-  @OneToOne(() => QuizEntity)
+  @OneToOne(() => QuestionEntity, (question) => question.id)
   @JoinColumn()
-  quiz: QuizEntity;
+  question: QuestionEntity; // questionId 생성
 }

--- a/apps/server/src/result/result.controller.ts
+++ b/apps/server/src/result/result.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Post, Body, Param, ParseIntPipe } from '@nestjs/common';
+import { ResultService } from './result.service';
+import { CreateResultDto } from './dto/create-result.dto';
+
+@Controller('result')
+export class ResultController {
+  constructor(private readonly resultService: ResultService) {}
+
+  @Post(':quizId')
+  create(
+    @Param('quizId', ParseIntPipe) quizId: number,
+    @Body() createResultDto: CreateResultDto,
+  ) {
+    return this.resultService.create(quizId, createResultDto);
+  }
+}

--- a/apps/server/src/result/result.module.ts
+++ b/apps/server/src/result/result.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { ResultService } from './result.service';
+import { ResultController } from './result.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ResultEntity } from './entities/result.entity';
+import { QuestionEntity } from 'src/question/entities/question.entity';
+import { QuizEntity } from 'src/quiz/entities/quiz.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([ResultEntity, QuizEntity, QuestionEntity]),
+  ],
+  controllers: [ResultController],
+  providers: [ResultService],
+})
+export class ResultModule {}

--- a/apps/server/src/result/result.service.ts
+++ b/apps/server/src/result/result.service.ts
@@ -1,0 +1,153 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { QuestionEntity } from 'src/question/entities/question.entity';
+import { Repository } from 'typeorm';
+import { CreateResultDto } from './dto/create-result.dto';
+import OpenAI from 'openai';
+import { ConfigService } from '@nestjs/config';
+import { ResultEntity } from './entities/result.entity';
+
+@Injectable()
+export class ResultService {
+  private readonly openai: OpenAI;
+
+  constructor(
+    private readonly configService: ConfigService,
+    @InjectRepository(ResultEntity)
+    private readonly resultRepository: Repository<ResultEntity>,
+    @InjectRepository(QuestionEntity)
+    private readonly questionRepository: Repository<QuestionEntity>,
+  ) {
+    this.openai = new OpenAI({
+      apiKey: this.configService.get<string>('OPENAI_API_KEY'),
+    });
+  }
+
+  async create(quizId: number, createResultDto: CreateResultDto) {
+    const questions = await this.questionRepository.find({
+      where: { quiz: { id: quizId } },
+    });
+
+    const resultsToSave = [];
+
+    for (const question of questions) {
+      console.log(question.id);
+      const answers = createResultDto.answers.find(
+        (answer) => answer.questionId === question.id,
+      );
+
+      let results;
+
+      if (question.type === 'multiple_choice') {
+        const options = question.options;
+
+        results = await this.getCorrectAnswerMultipleChoice(
+          question.title,
+          options.split(','),
+          answers.userAnswer,
+        );
+      } else {
+        results = await this.getCorrectAnswerSentence(
+          question.title,
+          answers.userAnswer,
+        );
+      }
+      resultsToSave.push({
+        question: question.id,
+        userAnswer: answers.userAnswer,
+        isCorrect: results.isCorrect,
+        correctAnswer: results.correctAnswer,
+        description: results.description,
+      });
+    }
+
+    return await this.resultRepository.save(resultsToSave);
+  }
+
+  async getCorrectAnswerMultipleChoice(
+    title: string,
+    options: string[],
+    userAnswer: string,
+  ): Promise<{
+    isCorrect: boolean;
+    description: string;
+    correctAnswer: string;
+  }> {
+    const prompt = `
+    Question: ${title}
+    Options: ${options.join(', ')}
+
+    User's Answer: "${userAnswer}"
+
+    Evaluation Criteria:
+    1. Correctness Evaluation:
+      - Determine if the user's answer matches the correct option among the provided choices.
+      - Return 'true' if the user's answer is correct, or 'false' if it is incorrect.
+    2. Detailed Explanation:
+      - If the user's answer is correct, explain why it is the correct answer, focusing on the technical or logical reasons.
+      - If the user's answer is incorrect, clearly explain why it is wrong and provide guidance to help the user understand the correct choice.
+    3. Correct Answer:
+      - If the user's answer is incorrect, specify the correct answer clearly and explain why it is the most appropriate choice among the options.
+
+    Your output should strictly follow this JSON format:
+    {
+      "isCorrect": true or false,
+      "description": "Provide a detailed explanation in Korean. If the answer is correct, explain why it is correct. If incorrect, explain the mistake and provide constructive feedback.",
+      "correctAnswer": "Provide the correct answer in Korean and explain why it is the best choice."
+    }
+  `;
+
+    const response = await this.openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 400,
+      temperature: 0,
+    });
+
+    const result = response.choices[0].message?.content;
+
+    return JSON.parse(result || '{}');
+  }
+
+  async getCorrectAnswerSentence(
+    title: string,
+    userAnswer: string,
+  ): Promise<{
+    isCorrect: boolean;
+    description: string;
+    correctAnswer: string;
+  }> {
+    const prompt = `
+    Evaluate the following answer to a question and provide the results in JSON format.
+  
+    Question: "${title}"
+  
+    User's Answer: "${userAnswer}"
+  
+    Evaluation Criteria:
+    1. Determine if the user's answer is correct ('True') or incorrect ('False') based on the question's requirements.
+    2. Provide a detailed explanation in Korean tailored to the user's answer:
+       - If the answer is correct, provide additional technical insights, examples, or related concepts to deepen the user's understanding.
+       - If the answer is incorrect, analyze the user's response to explain why it is incorrect. Offer constructive feedback on how to approach the question correctly and clarify the correct answer.
+    3. Include the correct or model answer in Korean for clarity.
+  
+    Your output should strictly follow this JSON format:
+    {
+      "isCorrect": true or false,
+      "description": "A detailed explanation in Korean based on the user's answer. Include technical insights or feedback depending on the correctness.",
+      "correctAnswer": "The correct answer in Korean or a detailed explanation of the concept related to the question."
+    }
+    `;
+
+    const response = await this.openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 400,
+      temperature: 0,
+    });
+
+    const result = response.choices[0].message?.content;
+
+    return JSON.parse(result || '{}');
+  }
+}


### PR DESCRIPTION
## ✅ 이슈 번호

close #11 

<br>

## 🪄 작업 내용 (변경 사항)

- [x] 퀴즈 정답 확인 로직 생성 `/result/:quizId`
- [x] 퀴즈 문제 조회 생성 `/quiz/:quizId`
- [x] Question Entity와 Result Entity 1:1 관계 설정

<br>

## 📸 스크린샷
- 사용자 답안에 대한 퀴즈 결과 및 해설 생성
<img width="843" alt="스크린샷 2024-12-04 오후 3 24 13" src="https://github.com/user-attachments/assets/dfc6322d-922c-4726-bb57-54b72365c2a6" />

<br>

- 퀴즈 문제 조회 
<img width="846" alt="스크린샷 2024-12-04 오후 3 24 59" src="https://github.com/user-attachments/assets/49fd3030-193a-45de-ab81-db25820f7456" />

<br>

## 📍 트러블 슈팅

**1. Quiz : Result = 1 : N 관계 변경**
- 원인
     - Quiz와 Result가 1:N로 관계를 맺는 구조에서는 결과가 퀴즈 전체 단위로 관리되었기 때문에 각 질문에 대한 결과를 명확히 구분하기 어렵다는 문제를 깨달았습니다.
     - 또한, 각 질문에 대한 정답 확인과 사용자의 답안 평가가 이루어져야 했지만 Quiz와 1:1 관계로 설정되어 있어 개별 질문 단위로 결과를 처리할 수 없었습니다.

- 해결 방법
     - 각 질문별로 독립적인 결과를 관리할 수 있도록 Quiz 대신 **Question Entity와 Result Entity가 1:1 관계를 맺도록 수정**하였습니다.
     - 개별 질문 단위로 결과를 저장하여 각 결과를 독립적으로 관리 가능하도록 하였습니다.

<br>

**2. Result Entity에 questionId 가 `null` 값으로 담기는 이슈**
- Result Entity의 데이터를 DB에 저장하려고 할 때, 외래키 컬럼 `questionId`가 null 값으로 저장되는 문제가 발생하였습니다.
```
ERROR [ExceptionsHandler] null value in column "questionId" of relation "result" violates not-null constraint
```

- 원인
     1.  Result Entity에서 `question` 이라는 필드를 정의했으며, 해당 필드는 DB에서는 `questionId`라는 이름으로 자동 매핑됩니다.
     ```
      // result.entity.ts
      @OneToOne(() => QuestionEntity, (question) => question.id, {
          cascade: true,
          nullable: false,
        })
      @JoinColumn()
      question: QuestionEntity; // questionId 생성
     ```  
    
     - TypeORM은 Entity 필드 이름 `question`을 기준으로 외래키를 처리하고, 데이터베이스 실제 컬럼 이름은 `questionId`로 저장됩니다.
     <br>

     
     2. 데이터를 저장하는 코드에서 TypeORM의 매핑 규칙을 고려하지 않고, 데이터베이스에 생성된 실제 칼럼 이름(questionId)를 사용
         ```
            resultsToSave.push({
	              questionId: question.id,  // 잘못된 필드 이름 사용
	              userAnswer: answers.userAnswer,
	              isCorrect: results.isCorrect,
	              correctAnswer: results.correctAnswer,
	              description: results.description,
	            });
            }
            
            return await this.resultRepository.save(resultsToSave);
         ```

     - **TypeORM은 외래키를 매핑할 때 Entity 필드를 참조**하므로, questionId로 데이터베이스에 값을 저장하려고 하면 외래키가 null 값으로 처리됨
     - 그러므로 데이터베이스 컬럼 이름을 직접 참조하려고 하면, ORM의 매핑 규칙과 충돌이 발생합니다.

- 해결 방법
     -  `questionId` 대신 Entity에 정의된 필드 이름 `question`을 사용하여 데이터를 저장하도록 수정하였습니다.
           ```
            resultsToSave.push({
	              question: question.id,  // Entity에 정의된 필드 이름에 맞게 수정
	              userAnswer: answers.userAnswer,
	              isCorrect: results.isCorrect,
	              correctAnswer: results.correctAnswer,
	              description: results.description,
	            });
            }
           ```
          <img width="1271" alt="스크린샷 2024-12-04 오후 3 57 07" src="https://github.com/user-attachments/assets/2500f661-9e5b-4c54-bb90-9944244476bd">
           - null 값으로 인해 외래키 컬럼 `questionId`가 저장되지 않던 문제를 해결하였습니다.


