### PR TITLE
[Server] 카카오 소셜 로그인 구현

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     {
       "mode": "auto"
     }
-  ]
+  ],
+  "cSpell.words": ["kakao"]
 }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -26,6 +26,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/axios": "^4.0.0",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.2.3",
@@ -36,7 +37,6 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^8.0.1",
     "@nestjs/typeorm": "^10.0.2",
-    "@types/passport-local": "^1.0.38",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
@@ -44,6 +44,7 @@
     "openai": "^4.73.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
+    "passport-kakao": "^1.0.1",
     "passport-local": "^1.0.0",
     "pg": "^8.13.0",
     "reflect-metadata": "^0.2.0",
@@ -61,6 +62,8 @@
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",
     "@types/passport-jwt": "^4.0.1",
+    "@types/passport-kakao": "^1.0.3",
+    "@types/passport-local": "^1.0.38",
     "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -37,6 +37,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^8.0.1",
     "@nestjs/typeorm": "^10.0.2",
+    "axios": "^1.7.9",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 import { PortfolioModule } from './portfolio/portfolio.module';
 import { ResultModule } from './result/result.module';
+import { OauthModule } from './oauth/oauth.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { ResultModule } from './result/result.module';
     AuthModule,
     PortfolioModule,
     ResultModule,
+    OauthModule,
   ],
 })
 export class AppModule implements NestModule {

--- a/apps/server/src/oauth/oauth.controller.ts
+++ b/apps/server/src/oauth/oauth.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Query, Req, Res, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { OauthService } from './oauth.service';
+import { Response } from 'express';
+
+@Controller('oauth')
+export class OauthController {
+  constructor(private readonly oAuthService: OauthService) {}
+
+  @Get('kakao')
+  @UseGuards(AuthGuard('kakao'))
+  async kakaoLogin(@Req() req) {}
+
+  @Get('kakao/callback')
+  async kakaoLoginCallback(@Query('code') code: string, @Res() res: Response) {
+    try {
+      const { accessToken } = await this.oAuthService.kakaoLogin(code);
+
+      res.cookie('accessToken', accessToken, {
+        httpOnly: true,
+      });
+
+      return res.redirect(`${process.env.CLIENT_CALLBACK_URI}`);
+    } catch (error) {
+      return res.status(500).json({ message: '카카오 로그인 실패' });
+    }
+  }
+}

--- a/apps/server/src/oauth/oauth.module.ts
+++ b/apps/server/src/oauth/oauth.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { PassportModule } from '@nestjs/passport';
+import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { UserEntity } from 'src/user/entities/user.entity';
+import { OauthController } from './oauth.controller';
+import { OauthService } from './oauth.service';
+import { JwtKakaoStrategy } from './strategy/jwt.kakao.strategy';
+
+@Module({
+  imports: [
+    PassportModule,
+    TypeOrmModule.forFeature([UserEntity]),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: '1h' },
+      }),
+      inject: [ConfigService],
+    }),
+    ConfigModule,
+  ],
+  controllers: [OauthController],
+  providers: [OauthService, JwtKakaoStrategy],
+  exports: [OauthService, JwtModule],
+})
+export class OauthModule {}

--- a/apps/server/src/oauth/oauth.service.ts
+++ b/apps/server/src/oauth/oauth.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import axios from 'axios';
+import { UserEntity } from 'src/user/entities/user.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class OauthService {
+  constructor(
+    private readonly jwtService: JwtService,
+    @InjectRepository(UserEntity)
+    private readonly userRepository: Repository<UserEntity>,
+  ) {}
+
+  async kakaoLogin(code: string) {
+    try {
+      const tokenResponse = await axios.post(
+        'https://kauth.kakao.com/oauth/token',
+        {
+          grant_type: 'authorization_code',
+          client_id: process.env.KAKAO_ID,
+          client_secret: process.env.KAKAO_SECRET,
+          redirect_uri: process.env.KAKAO_CALLBACK_URI,
+          code: code,
+        },
+        { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+      );
+
+      const accessToken = tokenResponse.data.access_token;
+
+      const userResponse = await axios.get(
+        'https://kapi.kakao.com/v2/user/me',
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        },
+      );
+
+      const kakaoUser = userResponse.data;
+
+      if (!kakaoUser.kakao_account.email) {
+        throw new Error('카카오 계정에서 이메일을 제공하지 않습니다.');
+      }
+
+      let user = await this.userRepository.findOne({
+        where: { email: kakaoUser.kakao_account.email },
+      });
+
+      if (!user) {
+        user = this.userRepository.create({
+          email: kakaoUser.kakao_account.email,
+          name: kakaoUser.properties.nickname,
+        });
+        user = await this.userRepository.save(user);
+      }
+
+      const payload = { sub: user.id, email: user.email, name: user.name };
+      const jwtToken = this.jwtService.sign(payload);
+
+      return { accessToken: jwtToken, user };
+    } catch (error) {
+      throw new InternalServerErrorException('카카오 로그인 처리 중 오류 발생');
+    }
+  }
+}

--- a/apps/server/src/oauth/strategy/jwt.kakao.strategy.ts
+++ b/apps/server/src/oauth/strategy/jwt.kakao.strategy.ts
@@ -7,10 +7,10 @@ import { ConfigService } from '@nestjs/config';
 export class JwtKakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
   constructor(private readonly configService: ConfigService) {
     super({
-      clientID: configService.get('KAKAO_ID'),
-      clientSecret: configService.get('KAKAO_SECRET'),
-      callbackURL: configService.get('KAKAO_CALLBACK_URL'),
-      // scope: ["account_email", "profile_nickname"],
+      clientID: configService.get<string>('KAKAO_ID'),
+      clientSecret: configService.get<string>('KAKAO_SECRET'),
+      callbackURL: configService.get<string>('KAKAO_CALLBACK_URL'),
+      scope: ['account_email'],
     });
   }
 

--- a/apps/server/src/oauth/strategy/jwt.kakao.strategy.ts
+++ b/apps/server/src/oauth/strategy/jwt.kakao.strategy.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Profile, Strategy } from 'passport-kakao';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class JwtKakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
+  constructor(private readonly configService: ConfigService) {
+    super({
+      clientID: configService.get('KAKAO_ID'),
+      clientSecret: configService.get('KAKAO_SECRET'),
+      callbackURL: configService.get('KAKAO_CALLBACK_URL'),
+      // scope: ["account_email", "profile_nickname"],
+    });
+  }
+
+  async validate(
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+    done: (error: any, user?: any, info?: any) => void,
+  ) {
+    try {
+      const { _json } = profile;
+      const user = {
+        email: _json.kakao_account.email,
+        nickname: _json.properties.nickname,
+        photo: _json.properties.profile_image,
+      };
+      done(null, user);
+    } catch (error) {
+      done(error);
+    }
+  }
+}

--- a/apps/server/src/user/entities/user.entity.ts
+++ b/apps/server/src/user/entities/user.entity.ts
@@ -22,7 +22,7 @@ export class UserEntity extends BaseEntity {
   @Column({ unique: true })
   email: string;
 
-  @Column()
+  @Column({ nullable: true })
   @Exclude({ toPlainOnly: true })
   password: string;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
 
   apps/server:
     dependencies:
+      '@nestjs/axios':
+        specifier: ^4.0.0
+        version: 4.0.0(@nestjs/common@10.4.15)(axios@1.7.9)(rxjs@7.8.1)
       '@nestjs/cli':
         specifier: ^10.0.0
         version: 10.4.9
@@ -129,9 +132,6 @@ importers:
       '@nestjs/typeorm':
         specifier: ^10.0.2
         version: 10.0.2(@nestjs/common@10.4.15)(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20)
-      '@types/passport-local':
-        specifier: ^1.0.38
-        version: 1.0.38
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1
@@ -153,6 +153,9 @@ importers:
       passport-jwt:
         specifier: ^4.0.1
         version: 4.0.1
+      passport-kakao:
+        specifier: ^1.0.1
+        version: 1.0.1
       passport-local:
         specifier: ^1.0.0
         version: 1.0.0
@@ -199,6 +202,12 @@ importers:
       '@types/passport-jwt':
         specifier: ^4.0.1
         version: 4.0.1
+      '@types/passport-kakao':
+        specifier: ^1.0.3
+        version: 1.0.3
+      '@types/passport-local':
+        specifier: ^1.0.38
+        version: 1.0.38
       '@types/supertest':
         specifier: ^6.0.0
         version: 6.0.2
@@ -2065,6 +2074,18 @@ packages:
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
     dev: false
 
+  /@nestjs/axios@4.0.0(@nestjs/common@10.4.15)(axios@1.7.9)(rxjs@7.8.1):
+    resolution: {integrity: sha512-1cB+Jyltu/uUPNQrpUimRHEQHrnQrpLzVj6dU3dgn6iDDDdahr10TgHFGTmw5VuJ9GzKZsCLDL78VSwJAs/9JQ==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      axios: ^1.3.1
+      rxjs: ^7.0.0
+    dependencies:
+      '@nestjs/common': 10.4.15(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      axios: 1.7.9
+      rxjs: 7.8.1
+    dev: false
+
   /@nestjs/cli@10.4.9:
     resolution: {integrity: sha512-s8qYd97bggqeK7Op3iD49X2MpFtW4LVNLAwXFkfbRxKME6IYT7X0muNTJ2+QfI8hpbNx9isWkrLWIp+g5FOhiA==}
     engines: {node: '>= 16.14'}
@@ -2811,6 +2832,7 @@ packages:
     dependencies:
       '@types/connect': 3.4.38
       '@types/node': 20.17.14
+    dev: true
 
   /@types/classnames@2.3.4:
     resolution: {integrity: sha512-dwmfrMMQb9ujX1uYGvB5ERDlOzBNywnZAZBtOe107/hORWP05ESgU4QyaanZMWYYfd2BzrG78y13/Bju8IQcMQ==}
@@ -2823,6 +2845,7 @@ packages:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
       '@types/node': 20.17.14
+    dev: true
 
   /@types/cookiejar@2.1.5:
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
@@ -2850,6 +2873,7 @@ packages:
       '@types/qs': 6.9.18
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
+    dev: true
 
   /@types/express@4.17.21:
     resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
@@ -2858,6 +2882,7 @@ packages:
       '@types/express-serve-static-core': 4.19.6
       '@types/qs': 6.9.18
       '@types/serve-static': 1.15.7
+    dev: true
 
   /@types/glob@7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
@@ -2874,6 +2899,7 @@ packages:
 
   /@types/http-errors@2.0.4:
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
+    dev: true
 
   /@types/inquirer@6.5.0:
     resolution: {integrity: sha512-rjaYQ9b9y/VFGOpqBEXRavc3jh0a+e6evAbI31tMda8VlPaSy0AZJfXsvmIe3wklc7W6C3zCSfleuMXR7NOyXw==}
@@ -2930,6 +2956,7 @@ packages:
 
   /@types/mime@1.3.5:
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+    dev: true
 
   /@types/minimatch@5.1.2:
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
@@ -2964,33 +2991,44 @@ packages:
       '@types/passport-strategy': 0.2.38
     dev: true
 
+  /@types/passport-kakao@1.0.3:
+    resolution: {integrity: sha512-McK5kpeiOptvjIPkiA/QS3k82//z5JM7Y3yBLMDvEA0QMMhFMcWUHhyebL1Qy+0i0n8jS+Oe4U6xAvkU22SXXA==}
+    dependencies:
+      '@types/express': 4.17.21
+      '@types/passport': 1.0.17
+    dev: true
+
   /@types/passport-local@1.0.38:
     resolution: {integrity: sha512-nsrW4A963lYE7lNTv9cr5WmiUD1ibYJvWrpE13oxApFsRt77b0RdtZvKbCdNIY4v/QZ6TRQWaDDEwV1kCTmcXg==}
     dependencies:
       '@types/express': 4.17.21
       '@types/passport': 1.0.17
       '@types/passport-strategy': 0.2.38
-    dev: false
+    dev: true
 
   /@types/passport-strategy@0.2.38:
     resolution: {integrity: sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==}
     dependencies:
       '@types/express': 4.17.21
       '@types/passport': 1.0.17
+    dev: true
 
   /@types/passport@1.0.17:
     resolution: {integrity: sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==}
     dependencies:
       '@types/express': 4.17.21
+    dev: true
 
   /@types/prop-types@15.7.14:
     resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
 
   /@types/qs@6.9.18:
     resolution: {integrity: sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==}
+    dev: true
 
   /@types/range-parser@1.2.7:
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+    dev: true
 
   /@types/react-dom@18.3.5(@types/react@18.3.18):
     resolution: {integrity: sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==}
@@ -3015,6 +3053,7 @@ packages:
     dependencies:
       '@types/mime': 1.3.5
       '@types/node': 20.17.14
+    dev: true
 
   /@types/serve-static@1.15.7:
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
@@ -3022,6 +3061,7 @@ packages:
       '@types/http-errors': 2.0.4
       '@types/node': 20.17.14
       '@types/send': 0.17.4
+    dev: true
 
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -4081,6 +4121,16 @@ packages:
     resolution: {integrity: sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==}
     engines: {node: '>=4'}
     dev: true
+
+  /axios@1.7.9:
+    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.1
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -6089,6 +6139,16 @@ packages:
   /flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
     dev: true
+
+  /follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -8169,6 +8229,10 @@ packages:
       boolbase: 1.0.0
     dev: true
 
+  /oauth@0.9.15:
+    resolution: {integrity: sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==}
+    dev: false
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -8457,11 +8521,27 @@ packages:
       passport-strategy: 1.0.0
     dev: false
 
+  /passport-kakao@1.0.1:
+    resolution: {integrity: sha512-uItaYRVrTHL6iGPMnMZvPa/O1GrAdh/V6EMjOHcFlQcVroZ9wgG7BZ5PonMNJCxfHQ3L2QVNRnzhKWUzSsumbw==}
+    dependencies:
+      passport-oauth2: 1.1.2
+      pkginfo: 0.3.1
+    dev: false
+
   /passport-local@1.0.0:
     resolution: {integrity: sha512-9wCE6qKznvf9mQYYbgJ3sVOHmCWoUNMVFoZzNoznmISbhnNNPhN9xfY3sLmScHMetEJeoY7CXwfhCe7argfQow==}
     engines: {node: '>= 0.4.0'}
     dependencies:
       passport-strategy: 1.0.0
+    dev: false
+
+  /passport-oauth2@1.1.2:
+    resolution: {integrity: sha512-wpsGtJDHHQUjyc9WcV9FFB0bphFExpmKtzkQrxpH1vnSr6RcWa3ZEGHx/zGKAh2PN7Po9TKYB1fJeOiIBspNPA==}
+    engines: {node: '>= 0.4.0'}
+    dependencies:
+      oauth: 0.9.15
+      passport-strategy: 1.0.0
+      uid2: 0.0.4
     dev: false
 
   /passport-strategy@1.0.0:
@@ -8616,6 +8696,11 @@ packages:
     dependencies:
       find-up: 4.1.0
     dev: true
+
+  /pkginfo@0.3.1:
+    resolution: {integrity: sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==}
+    engines: {node: '>= 0.4.0'}
+    dev: false
 
   /pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -8811,7 +8896,6 @@ packages:
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: true
 
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -10394,6 +10478,10 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /uid2@0.0.4:
+    resolution: {integrity: sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==}
+    dev: false
 
   /uid@2.0.2:
     resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@nestjs/typeorm':
         specifier: ^10.0.2
         version: 10.0.2(@nestjs/common@10.4.15)(@nestjs/core@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20)
+      axios:
+        specifier: ^1.7.9
+        version: 1.7.9
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1


### PR DESCRIPTION
## ✅ 이슈 번호

close #23 

<br>

## 🪄 작업 내용 (변경 사항)

- [x] 카카오 소셜 로그인 구현

<br>

## 📸 스크린샷

<br>

## 💡 설명

### **1️⃣ 사용자 로그인 요청**
- 클라이언트 : 사용자가 로그인 요청 (`${SERVER_URL}/oauth/kakao` 요청)
- 서버 : `passport-kakao` 실행 → **카카오 로그인 페이지(`https://kauth.kakao.com/oauth/authorize`)로 리다이렉트**

### **2️⃣ 카카오 로그인 후, 인가 코드(code) 반환**
- 사용자가 카카오 로그인 완료하면 **카카오 서버는 인가 코드(code)를 백엔드로 전달**
- `GET /oauth/kakao/callback`에서 **인가 코드 수신**

### **3️⃣ 백엔드에서 Access Token 발급 요청**
- `OauthService.kakaoLogin(code)` 실행  
- `https://kauth.kakao.com/oauth/token` 호출하여 `accessToken` 발급

### **4️⃣ 카카오 API를 통해 사용자 정보 조회**
- `https://kapi.kakao.com/v2/user/me` 호출하여 사용자 이메일, 닉네임 정보 받은 후
- DB에서 사용자 조회 및 자동 회원가입 처리

### **5️⃣ JWT 발급 및 쿠키 저장**
- JWT 생성
- **HttpOnly Cookie에 accessToken 저장** → `res.cookie('accessToken', accessToken, { httpOnly: true })`
- `CLIENT_CALLBACK_URI`로 리다이렉트

<br>

## 📍 트러블 슈팅
