### PR TITLE
[Client] Refresh Token 만료 시 처리 API 요청

### DIFF
--- a/apps/client/src/apis/auth.ts
+++ b/apps/client/src/apis/auth.ts
@@ -1,0 +1,31 @@
+export async function kakaoLogout() {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/oauth/kakao/logout`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error('카카오 로그아웃에 실패하였습니다.');
+  }
+
+  return response;
+}
+
+export async function refreshAccessToken() {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error('카카오 로그아웃에 실패하였습니다.');
+  }
+
+  return response;
+}

--- a/apps/client/src/apis/challenge.ts
+++ b/apps/client/src/apis/challenge.ts
@@ -3,7 +3,10 @@ import { TQuiz } from '@/types/quiz.type';
 
 export async function getChallengeQuestions(challengeId: number): Promise<TQuiz | null> {
   const response = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/quiz/${challengeId}`, {
-    cache: 'no-cache'
+    cache: 'no-cache',
+    headers: {
+      'Cache-Control': 'no-cache, must-revalidate'
+    }
   });
 
   if (!response) {

--- a/apps/client/src/apis/challenge.ts
+++ b/apps/client/src/apis/challenge.ts
@@ -1,9 +1,15 @@
-export async function getChallengeQuestions(challengeId: number) {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/quiz/${challengeId}`);
+import { fetchWithAuth } from '@/interceptors/authFetchInterceptor.ts';
+import { TQuiz } from '@/types/quiz.type';
 
-  if (!res.ok) {
-    throw new Error('Failed to fetch data');
+export async function getChallengeQuestions(challengeId: number): Promise<TQuiz | null> {
+  const response = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/quiz/${challengeId}`, {
+    cache: 'no-cache'
+  });
+
+  if (!response) {
+    console.error('퀴즈 정보를 불러오지 못했습니다.');
+    return null;
   }
 
-  return res.json();
+  return response as TQuiz;
 }

--- a/apps/client/src/apis/quiz.ts
+++ b/apps/client/src/apis/quiz.ts
@@ -1,5 +1,5 @@
 import { fetchWithAuth } from '@/interceptors/authFetchInterceptor.ts';
-import { TQuizRequest } from '@/types/quiz.type';
+import { TQuiz, TQuizRequest } from '@/types/quiz.type';
 
 export async function createQuiz(quizRequest: TQuizRequest) {
   const response = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/quiz`, {
@@ -15,5 +15,5 @@ export async function createQuiz(quizRequest: TQuizRequest) {
     return null;
   }
 
-  return response;
+  return response as TQuiz;
 }

--- a/apps/client/src/apis/quiz.ts
+++ b/apps/client/src/apis/quiz.ts
@@ -1,7 +1,8 @@
+import { fetchWithAuth } from '@/interceptors/authFetchInterceptor.ts';
 import { TQuizRequest } from '@/types/quiz.type';
 
 export async function createQuiz(quizRequest: TQuizRequest) {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/quiz`, {
+  const response = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/quiz`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
@@ -9,9 +10,10 @@ export async function createQuiz(quizRequest: TQuizRequest) {
     body: JSON.stringify(quizRequest)
   });
 
-  if (!res.ok) {
-    throw new Error('Failed to fetch data');
+  if (!response) {
+    console.error('퀴즈 정보를 생성하지 못했습니다.');
+    return null;
   }
 
-  return res.json();
+  return response;
 }

--- a/apps/client/src/apis/result.ts
+++ b/apps/client/src/apis/result.ts
@@ -1,7 +1,8 @@
-import { TResultRequest } from '@/types/result.type';
+import { fetchWithAuth } from '@/interceptors/authFetchInterceptor.ts';
+import { TResultRequest, TResultResponse } from '@/types/result.type';
 
 export async function createResult({ quizId, resultRequest }: { quizId: number; resultRequest: TResultRequest }) {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/result/${quizId}`, {
+  const response = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/result/${quizId}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
@@ -9,19 +10,23 @@ export async function createResult({ quizId, resultRequest }: { quizId: number; 
     body: JSON.stringify(resultRequest)
   });
 
-  if (!res.ok) {
-    throw new Error('Failed to fetch data');
+  if (!response) {
+    console.error('퀴즈 정보를 불러오지 못했습니다.');
+    return null;
   }
 
-  return res.json();
+  return response;
 }
 
-export async function getResult(quizId: number) {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/result/${quizId}`);
+export async function getResult(quizId: number): Promise<TResultResponse[] | null> {
+  const response = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/result/${quizId}`, {
+    cache: 'no-cache'
+  });
 
-  if (!res.ok) {
-    throw new Error('Failed to fetch data');
+  if (!response) {
+    console.error('퀴즈 정보를 불러오지 못했습니다.');
+    return null;
   }
 
-  return res.json();
+  return response as TResultResponse[];
 }

--- a/apps/client/src/apis/result.ts
+++ b/apps/client/src/apis/result.ts
@@ -20,7 +20,10 @@ export async function createResult({ quizId, resultRequest }: { quizId: number; 
 
 export async function getResult(quizId: number): Promise<TResultResponse[] | null> {
   const response = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/result/${quizId}`, {
-    cache: 'no-cache'
+    cache: 'no-cache',
+    headers: {
+      'Cache-Control': 'no-cache, must-revalidate'
+    }
   });
 
   if (!response) {

--- a/apps/client/src/apis/user.ts
+++ b/apps/client/src/apis/user.ts
@@ -1,32 +1,12 @@
+import { fetchWithAuth } from '@/interceptors/authFetchInterceptor.ts';
 import { TUserResponse } from '@/types/user.type';
 
-export async function getUser(): Promise<TUserResponse> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/user/me`, {
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  });
+export async function getUser(): Promise<TUserResponse | null> {
+  const response = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/user/me`);
 
-  if (!res.ok) {
-    throw new Error('Unauthorized');
+  if (!response) {
+    return null;
   }
 
-  return res.json();
-}
-
-export async function kakaoLogout() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/oauth/kakao/logout`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  });
-
-  if (!res.ok) {
-    throw new Error('카카오 로그아웃에 실패하였습니다.');
-  }
-
-  return res.json();
+  return response as TUserResponse;
 }

--- a/apps/client/src/app/challenge/[quizId]/page.tsx
+++ b/apps/client/src/app/challenge/[quizId]/page.tsx
@@ -2,7 +2,7 @@ import { getChallengeQuestions } from '@/apis/challenge';
 import Content from '@/components/Challenge/Content';
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 
-const ChallegePage = async ({ params }: { params: { quizId: number } }) => {
+const ChallengePage = async ({ params }: { params: { quizId: number } }) => {
   const { quizId } = params;
 
   const queryClient = new QueryClient();
@@ -19,4 +19,4 @@ const ChallegePage = async ({ params }: { params: { quizId: number } }) => {
   );
 };
 
-export default ChallegePage;
+export default ChallengePage;

--- a/apps/client/src/components/Challenge/Content.tsx
+++ b/apps/client/src/components/Challenge/Content.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { getChallengeQuestions } from '@/apis/challenge';
-import { TQuiz } from '@/types/quiz.type';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 import Timer from './Timer';
@@ -17,7 +16,7 @@ const Content = ({ quizId }: { quizId: number }) => {
 
   const { answers } = useAnswerStore((state) => state);
 
-  const { data } = useQuery<TQuiz>({
+  const { data } = useQuery({
     queryKey: ['challenge', quizId],
     queryFn: () => getChallengeQuestions(quizId),
     staleTime: Infinity

--- a/apps/client/src/components/Header.tsx
+++ b/apps/client/src/components/Header.tsx
@@ -8,8 +8,9 @@ import classNames from 'classnames';
 import { useUserStore } from '@/providers/user-provider';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState, useRef } from 'react';
-import { getUser, kakaoLogout } from '@/apis/user';
+import { getUser } from '@/apis/user';
 import { TbLogout2, TbBookmark } from 'react-icons/tb';
+import { kakaoLogout } from '@/apis/auth';
 
 const Header = () => {
   const router = useRouter();
@@ -20,9 +21,11 @@ const Header = () => {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const { data, isSuccess } = useQuery({
-    queryKey: ['user'],
+    queryKey: ['user', user?.id],
     queryFn: getUser,
-    enabled: !user
+    enabled: !user,
+    retry: false,
+    staleTime: 1000 * 60 * 5
   });
 
   useEffect(() => {

--- a/apps/client/src/components/Quiz/Category/SubmitButton.tsx
+++ b/apps/client/src/components/Quiz/Category/SubmitButton.tsx
@@ -25,7 +25,7 @@ const SubmitButton = () => {
         level: Number(levelParams)
       });
 
-      router.push(`/challenge/${quizData.data.id}`);
+      router.push(`/challenge/${quizData?.id}`);
     } catch (error) {
       toast.error('퀴즈 생성에 실패했습니다. 다시 시도해주세요.');
     }

--- a/apps/client/src/components/Result/Description.tsx
+++ b/apps/client/src/components/Result/Description.tsx
@@ -10,14 +10,14 @@ const Description = ({ quizId }: { quizId: number }) => {
   const { data } = useQuery({
     queryKey: ['result', quizId],
     queryFn: () => getResult(quizId),
-    staleTime: 5000,
-    refetchOnMount: true
+    staleTime: Infinity
   });
 
   const { isExplanationVisible, setIsExplanationVisible } = useExplanationVisibleStore((state) => state);
 
   const resultId = useResultStore((state) => state.resultId);
-  const resultData = data?.results?.find((result: TResultResponse) => result.id === resultId);
+
+  const resultData = data?.find((result: TResultResponse) => result.id === resultId);
 
   if (!resultData) {
     return <div className='text-gray-500'>결과를 불러오는 중입니다...</div>;
@@ -65,7 +65,7 @@ const Description = ({ quizId }: { quizId: number }) => {
           <p className='text-gray-600 text-sm font-medium'>📝 사용자의 답변</p>
           <p
             className={`text-lg font-semibold px-4 py-3 rounded-md ${
-              userAnswer === correctAnswer
+              isCorrect
                 ? 'bg-green-100 text-green-700 border border-green-400'
                 : 'bg-red-100 text-red-700 border border-red-400'
             }`}

--- a/apps/client/src/components/Result/TitleList.tsx
+++ b/apps/client/src/components/Result/TitleList.tsx
@@ -11,33 +11,32 @@ const TitleList = ({ quizId }: { quizId: number }) => {
   const { data } = useQuery({
     queryKey: ['result', quizId],
     queryFn: () => getResult(quizId),
-    staleTime: 5000, // TODO: Infinity로 변경
-    refetchOnMount: true
+    staleTime: Infinity
   });
 
   const { resultId, setResultId } = useResultStore((state) => state);
   const { setIsExplanationVisible } = useExplanationVisibleStore((state) => state);
 
   useEffect(() => {
-    if (data.results && resultId === 1) {
-      setResultId(data.results[0].id);
+    if (data && resultId === 1) {
+      setResultId(data?.[0]?.id ?? resultId);
     }
   }, []);
 
   const [isClickedQuestion, setIsClickedQuestion] = useState(1);
 
-  const correctCount = data.results.filter((result: TResultResponse) => result.isCorrect).length;
+  const correctCount = data?.filter((result: TResultResponse) => result.isCorrect).length;
 
   return (
     <div className='w-1/4'>
       <p className='font-semibold text-lg text-gray-700 mb-4'>
         <span className='text-green-600 font-bold'>
-          {correctCount < 10 ? String(correctCount).padStart(2, '0') : correctCount}
+          {correctCount && correctCount < 10 ? String(correctCount).padStart(2, '0') : correctCount}
         </span>{' '}
-        / {data.results.length}
+        / {data?.length}
       </p>
       <ul className='flex flex-col gap-2 p-4 bg-white shadow-lg rounded-xl border'>
-        {data?.results?.map((result: TResultResponse, index: number) => (
+        {data?.map((result: TResultResponse, index: number) => (
           <li
             key={result.id}
             className={`border-b border-gray-300 pb-2 px-3 py-2 rounded-md transition cursor-pointer ${

--- a/apps/client/src/interceptors/authFetchInterceptor.ts.ts
+++ b/apps/client/src/interceptors/authFetchInterceptor.ts.ts
@@ -1,0 +1,31 @@
+import { kakaoLogout, refreshAccessToken } from '@/apis/auth';
+
+export async function fetchWithAuth<T>(url: string, options: RequestInit = {}) {
+  let response = await fetch(url, {
+    ...options,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers
+    }
+  });
+
+  if (response.status === 401) {
+    try {
+      await refreshAccessToken();
+      response = await fetch(url, {
+        ...options,
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          ...options.headers
+        }
+      });
+    } catch (error) {
+      console.error('리프레시 토큰 만료', error);
+      await kakaoLogout();
+      return null;
+    }
+  }
+  return response.json() as Promise<T>;
+}

--- a/apps/server/src/auth/auth.service.ts
+++ b/apps/server/src/auth/auth.service.ts
@@ -42,14 +42,16 @@ export class AuthService {
   async refresh(req: Request, res: Response) {
     const refreshToken = req.cookies['refreshToken'];
     if (!refreshToken) {
-      throw new UnauthorizedException('리프레시 토큰이 존재하지 않습니다.');
+      return res
+        .status(403)
+        .json({ message: '리프레시 토큰이 존재하지 않습니다.' });
     }
 
     const user = await this.userRepository.findOne({
       where: { id: (req.user as JwtPayload).sub },
     });
     if (!user || !user.refreshToken) {
-      throw new UnauthorizedException('사용자를 찾을 수 없습니다.');
+      return res.status(403).json({ message: '유효하지 않은 사용자입니다.' });
     }
 
     const isRefreshTokenValid = await bcrypt.compare(
@@ -57,7 +59,9 @@ export class AuthService {
       user.refreshToken,
     );
     if (!isRefreshTokenValid) {
-      throw new UnauthorizedException('리프레시 토큰이 유효하지 않습니다.');
+      return res
+        .status(403)
+        .json({ message: '리프레시 토큰이 유효하지 않습니다.' });
     }
 
     const newAccessToken = this.jwtService.sign(

--- a/apps/server/src/auth/strategy/jwt.strategy.ts
+++ b/apps/server/src/auth/strategy/jwt.strategy.ts
@@ -1,7 +1,7 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
-import { Strategy } from 'passport-jwt';
+import { ExtractJwt, Strategy } from 'passport-jwt';
 
 export interface JwtPayload {
   sub: number;
@@ -15,12 +15,15 @@ export interface JwtPayload {
 export class JwtAccessStrategy extends PassportStrategy(Strategy, 'access') {
   constructor(private readonly configService: ConfigService) {
     super({
-      jwtFromRequest: (req) => {
-        if (!req.cookies || !req.cookies['accessToken']) {
-          throw new UnauthorizedException('액세스 토큰이 존재하지 않습니다.');
-        }
-        return req.cookies['accessToken'];
-      },
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (req) => {
+          let accessToken = null;
+          if (req && req.cookies) {
+            accessToken = req.cookies['accessToken'];
+          }
+          return accessToken;
+        },
+      ]),
       ignoreExpiration: false,
       secretOrKey: configService.get<string>('JWT_SECRET'),
     });
@@ -35,12 +38,15 @@ export class JwtAccessStrategy extends PassportStrategy(Strategy, 'access') {
 export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'refresh') {
   constructor(private readonly configService: ConfigService) {
     super({
-      jwtFromRequest: (req) => {
-        if (!req.cookies || !req.cookies['refreshToken']) {
-          throw new UnauthorizedException('리프레시 토큰이 존재하지 않습니다.');
-        }
-        return req.cookies['refreshToken'];
-      },
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (req) => {
+          let refreshToken = null;
+          if (req && req.cookies) {
+            refreshToken = req.cookies['refreshToken'];
+          }
+          return refreshToken;
+        },
+      ]),
       ignoreExpiration: false,
       secretOrKey: configService.get<string>('JWT_REFRESH_TOKEN'),
     });

--- a/apps/server/src/quiz/quiz.controller.ts
+++ b/apps/server/src/quiz/quiz.controller.ts
@@ -1,3 +1,4 @@
+import { AuthGuard } from '@nestjs/passport';
 import { CreateQuizDto } from './dto/create-quiz.dto';
 import { QuizService } from './quiz.service';
 import {
@@ -7,15 +8,21 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  UseGuards,
+  Req,
 } from '@nestjs/common';
+import { Request } from 'express';
+import { JwtPayload } from 'src/auth/strategy/jwt.strategy';
 
 @Controller('quiz')
 export class QuizController {
   constructor(private readonly quizService: QuizService) {}
 
   @Post()
-  async create(@Body() createQuizDto: CreateQuizDto) {
-    return await this.quizService.create(createQuizDto);
+  @UseGuards(AuthGuard('access'))
+  async create(@Body() createQuizDto: CreateQuizDto, @Req() req: Request) {
+    const userId = (req.user as JwtPayload).sub;
+    return await this.quizService.create(createQuizDto, userId);
   }
 
   @Get(':id')

--- a/apps/server/src/quiz/quiz.module.ts
+++ b/apps/server/src/quiz/quiz.module.ts
@@ -4,9 +4,10 @@ import { QuizEntity } from './entities/quiz.entity';
 import { QuizController } from './quiz.controller';
 import { QuizService } from './quiz.service';
 import { QuestionModule } from 'src/question/question.module';
+import { UserEntity } from 'src/user/entities/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([QuizEntity]), QuestionModule],
+  imports: [TypeOrmModule.forFeature([QuizEntity, UserEntity]), QuestionModule],
   controllers: [QuizController],
   providers: [QuizService],
 })

--- a/apps/server/src/quiz/quiz.service.ts
+++ b/apps/server/src/quiz/quiz.service.ts
@@ -43,16 +43,10 @@ export class QuizService {
     }));
     await this.questionService.saveQuestions(questions);
 
-    const finalQuiz = await this.quizRepository.findOne({
+    return await this.quizRepository.findOne({
       where: { id: savedQuiz.id },
       relations: ['questions', 'user'],
     });
-
-    return {
-      status: 'SUCCESS',
-      message: '퀴즈와 문제를 성공적으로 생성했습니다.',
-      data: finalQuiz,
-    };
   }
 
   findOne(id: number) {

--- a/apps/server/src/result/entities/result.entity.ts
+++ b/apps/server/src/result/entities/result.entity.ts
@@ -1,10 +1,11 @@
 import { BaseEntity } from 'src/common/entity/base.entity';
 import { QuestionEntity } from 'src/question/entities/question.entity';
-import { QuizEntity } from 'src/quiz/entities/quiz.entity';
+import { UserEntity } from 'src/user/entities/user.entity';
 import {
   Column,
   Entity,
   JoinColumn,
+  ManyToOne,
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
@@ -32,4 +33,7 @@ export class ResultEntity extends BaseEntity {
   })
   @JoinColumn()
   question: QuestionEntity; // questionId 생성
+
+  @ManyToOne(() => UserEntity, (user) => user.results)
+  user: UserEntity;
 }

--- a/apps/server/src/result/result.controller.ts
+++ b/apps/server/src/result/result.controller.ts
@@ -7,9 +7,14 @@ import {
   Get,
   UseInterceptors,
   ClassSerializerInterceptor,
+  UseGuards,
+  Req,
 } from '@nestjs/common';
 import { ResultService } from './result.service';
 import { CreateResultDto } from './dto/create-result.dto';
+import { AuthGuard } from '@nestjs/passport';
+import { Request } from 'express';
+import { JwtPayload } from 'src/auth/strategy/jwt.strategy';
 
 @Controller('result')
 @UseInterceptors(ClassSerializerInterceptor)
@@ -17,11 +22,14 @@ export class ResultController {
   constructor(private readonly resultService: ResultService) {}
 
   @Post(':quizId')
+  @UseGuards(AuthGuard('access'))
   create(
+    @Req() req: Request,
     @Param('quizId', ParseIntPipe) quizId: number,
     @Body() createResultDto: CreateResultDto,
   ) {
-    return this.resultService.create(quizId, createResultDto);
+    const userId = (req.user as JwtPayload).sub;
+    return this.resultService.create(quizId, createResultDto, userId);
   }
 
   @Get(':quizId')

--- a/apps/server/src/result/result.module.ts
+++ b/apps/server/src/result/result.module.ts
@@ -5,10 +5,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ResultEntity } from './entities/result.entity';
 import { QuestionEntity } from 'src/question/entities/question.entity';
 import { QuizEntity } from 'src/quiz/entities/quiz.entity';
+import { UserEntity } from 'src/user/entities/user.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ResultEntity, QuizEntity, QuestionEntity]),
+    TypeOrmModule.forFeature([
+      ResultEntity,
+      QuizEntity,
+      QuestionEntity,
+      UserEntity,
+    ]),
   ],
   controllers: [ResultController],
   providers: [ResultService],

--- a/apps/server/src/user/entities/user.entity.ts
+++ b/apps/server/src/user/entities/user.entity.ts
@@ -1,6 +1,8 @@
+import { Exclude } from 'class-transformer';
 import { BaseEntity } from 'src/common/entity/base.entity';
 import { PortfolioEntity } from 'src/portfolio/entities/portfolio.entity';
 import { QuizEntity } from 'src/quiz/entities/quiz.entity';
+import { ResultEntity } from 'src/result/entities/result.entity';
 import {
   Entity,
   PrimaryGeneratedColumn,
@@ -25,9 +27,11 @@ export class UserEntity extends BaseEntity {
   profileImage: string;
 
   @Column()
+  @Exclude()
   refreshToken: string;
 
   @Column()
+  @Exclude()
   kakaoAccessToken: string;
 
   @OneToOne(() => PortfolioEntity)
@@ -36,4 +40,7 @@ export class UserEntity extends BaseEntity {
 
   @OneToMany(() => QuizEntity, (quiz) => quiz.user)
   quizzes: QuizEntity[];
+
+  @OneToMany(() => ResultEntity, (result) => result.user)
+  results: ResultEntity[];
 }


### PR DESCRIPTION
## ✅ 이슈 번호

close #29

<br>

## 🪄 작업 내용 (변경 사항)

### Server

- [x] user entity : result entity = 1 : N 관계 설정
- [x] 인증이 필요한 컨트롤러에 인증 가드 부착

### Client

- [x] 액세스 토큰 재발급 API 생성
- [x] API 인증 요청을 위한 fetch 인터셉터 생성

<br>

## 📸 스크린샷

<br>

## 💡 설명

### 1. API 인증 요청을 위한 fetch 인터셉터 생성

- 모든 API 요청에는 액세스 토큰이 필요하지만 토큰이 만료되면 `401 Unauthorized` 응답이 발생합니다.
- 매 요청마다 수동으로 처리하는 대신, `fetchWithAuth`를 생성하여 인터셉터처럼 동작하도록 구현하여 인증 로직을 공통으로 생성하였습니다.
- 인증이 필요한 API 요청에 `fetchWithAuth`를 사용하여 자동으로 토큰 인증 및 갱신을 수행하도록 하였습니다.

**동작 방식**

1. API 요청이 들어오면 응답 상태를 확인합니다.
2. 액세스 토큰이 만료되었을 경우 (`response.status === 401`) `refreshAccessToken()`을 호출하여 새로운 토큰을 요청합니다.
3. 갱신이 성공하면 원래 요청을 다시 실행하여 새로운 응답을 받아 반환합니다.
4. 리프레시 토큰까지 만료된다면 `kakaoLogout()`을 호출하여 사용자 로그아웃을 진행합니다.

<br>

## 📍 트러블 슈팅

### 서버에서 새로운 퀴즈 데이터를 생성해도 브라우저에서 캐시된 데이터를 불러오는 이슈

<br>

<div align="center">
    <figure>
        <img width="1000" alt="Image" src="https://github.com/user-attachments/assets/2edb9677-e737-411c-b1e7-1702ee6d4e32" />
        <figcaption>최신 데이터가 반영된 데이터베이스</figcaption>
    </figure>
</div>

<br>

<div align="center">
    <figure>
        <img width="1000" alt="Image" src="https://github.com/user-attachments/assets/25793f08-d8aa-40a3-b574-13771428f8b9" />
        <figcaption>최신 데이터가 반영되지 못하고 예전 데이터를 불러오는 브라우저</figcaption>
    </figure>
</div>

- **원인**

1. fetch()의 기본 캐싱 정책(force-cache)이 자동 적용됨

    - Next.js에서 fetch()는 기본적으로 `force-cache`가 적용되어 서버에서 한 번 받아온 데이터를 캐싱합니다.
    - 따라서, 동일한 요청을 보낼 경우 캐싱된 데이터를 반환하며 최신 데이터가 반영되지 않습니다.

2. 데이터베이스 초기화 후, 동일한 quizId를 가진 데이터 다시 생성

     - `queryKey: ['challenge', params.quizId]`와 같이 quizId를 기반으로 데이터를 식별하므로, 기존에 브라우저가 캐싱했던 quizId와 동일한 데이터라고 판단하여 캐시된 데이터를 사용하였습니다.
    
      ```typescript
      export async function getChallengeQuestions(challengeId: number): Promise<TQuiz | null> {
        const response = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/quiz/${challengeId}`);
        // fetch()의 기본 캐싱 정책이 force-cache이기 때문에 서버 요청 후 데이터를 캐싱하며, 이후 요청에서는 캐시된 데이터를 그대로 반환합니다.
    
        if (!response) {
          console.error('퀴즈 정보를 불러오지 못했습니다.');
          return null;
        }
    
        return response as TQuiz;
      }
      ```

<br>

- **해결 방법**
  **✅ cache: 'no-cache' 옵션 적용**

  - fetch() 요청에 `{ cache: 'no-cache' }`를 적용하여 항상 새로운 요청을 서버로 보냅니다.
  - 서버에 항상 새로운 요청을 보내되, ETag를 통해 변경되지 않으면 기존 캐시를 사용할 수 있습니다.
  - 즉, 변경 여부를 확인하며 캐시를 활용할 수 있는 옵션입니다.

    <br>

  **✅ 서버에서는 `prefetchQuery`를 통해 데이터를 미리 가져오고, 클라이언트에서는 `staleTime: Infinity`를 설정하여 불필요한 API 호출 방지**

  - 서버에서 미리 데이터를 가져와 클라이언트에서 즉시 사용 가능하도록 하였습니다.
  - 클라이언트에서 불필요한 API 요청을 새로 보낼 필요가 없게 하였습니다.

    <div align="center">
    <figure>
        <img width="865" alt="Image" src="https://github.com/user-attachments/assets/9555eab8-d18d-45e0-b8bd-997575a748ec" />
        <figcaption>prefetchQuery 적용한 경우</figcaption>
    </figure>
    </div>

    - 서버에서 데이터를 미리 받아오기 때문에 클라이언트에서 추가 요청이 발생하지 않습니다.

    <br>

    <div align="center">
    <figure>
        <img width="862" alt="Image" src="https://github.com/user-attachments/assets/6daaa1dd-5093-4d17-9649-93b28f1835ff" />
        <figcaption>prefetchQuery 미적용</figcaption>
    </figure>
    </div>

    - 클라이언트에서 동일한 데이터를 다시 요청하는 추가적인 GET 요청이 발생합니다.
    - 페이지 이동 후 클라이언트의 `useQuery()`가 실행되면서 새롭게 서버에 데이터를 요청합니다.

- 또한, 퀴즈 데이터는 한번 생성되면 데이터가 절대 변경될 일이 없으므로 `staleTime: Infinity`를 설정하여, 불필요한 API 요청이 없도록 하였습니다.

➡️ **이를 통해 퀴즈 데이터를 새로 생성하더라도 브라우저가 이전 데이터를 캐싱하여 불러오는 문제를 해결할 수 있었습니다.**

