### PR TITLE
[Client] 내가 푼 퀴즈 페이지 마크업 및 API 연동

### DIFF
--- a/apps/client/src/apis/mypage.ts
+++ b/apps/client/src/apis/mypage.ts
@@ -1,0 +1,18 @@
+import { fetchWithAuth } from '@/interceptors/authFetchInterceptor.ts';
+import { TMyPageHistories } from '@/types/mypage.type';
+
+export async function getMyPageHistories(): Promise<TMyPageHistories | null> {
+  const response = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/user/my-quizzes`, {
+    cache: 'no-cache',
+    headers: {
+      'Cache-Control': 'no-cache, must-revalidate'
+    }
+  });
+
+  if (!response) {
+    console.error('퀴즈 정보를 불러오지 못했습니다.');
+    return null;
+  }
+
+  return response as TMyPageHistories;
+}

--- a/apps/client/src/app/mypage/layout.tsx
+++ b/apps/client/src/app/mypage/layout.tsx
@@ -1,0 +1,10 @@
+import SideBar from '@/components/MyPage/SideBar';
+
+export default function MyPageLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className='flex py-10'>
+      <SideBar />
+      <section className='flex-1'>{children}</section>
+    </div>
+  );
+}

--- a/apps/client/src/app/mypage/layout.tsx
+++ b/apps/client/src/app/mypage/layout.tsx
@@ -1,9 +1,12 @@
 import SideBar from '@/components/MyPage/SideBar';
+import { Suspense } from 'react';
 
 export default function MyPageLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className='flex py-10'>
-      <SideBar />
+      <Suspense>
+        <SideBar />
+      </Suspense>
       <section className='flex-1'>{children}</section>
     </div>
   );

--- a/apps/client/src/app/mypage/page.tsx
+++ b/apps/client/src/app/mypage/page.tsx
@@ -1,16 +1,9 @@
-import dynamic from 'next/dynamic';
-import { Suspense } from 'react';
+import Content from '@/components/MyPage/Content';
 
-const Content = dynamic(() => import('@/components/MyPage/Content'), {
-  ssr: false
-});
+export const dynamic = 'force-dynamic';
 
 const MyPage = () => {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <Content />
-    </Suspense>
-  );
+  return <Content />;
 };
 
 export default MyPage;

--- a/apps/client/src/app/mypage/page.tsx
+++ b/apps/client/src/app/mypage/page.tsx
@@ -1,5 +1,19 @@
+'use client';
+
+import ProfileSetting from '@/components/MyPage/ProfileSetting';
+import QuizHistorySetting from '@/components/MyPage/QuizHistorySetting';
+import { useSearchParams } from 'next/navigation';
+
 const MyPage = () => {
-  return <div>mypage</div>;
+  const searchParams = useSearchParams();
+  const tab = searchParams.get('tab');
+
+  return (
+    <div className='w-full max-w-[81rem]'>
+      {tab === 'profile' && <ProfileSetting />}
+      {tab === 'my-quizzes' && <QuizHistorySetting />}
+    </div>
+  );
 };
 
 export default MyPage;

--- a/apps/client/src/app/mypage/page.tsx
+++ b/apps/client/src/app/mypage/page.tsx
@@ -1,9 +1,12 @@
-import Content from '@/components/MyPage/Content';
-
-export const dynamic = 'force-dynamic';
+import MyPageContent from '@/components/MyPage/MyPageContent';
+import { Suspense } from 'react';
 
 const MyPage = () => {
-  return <Content />;
+  return (
+    <Suspense>
+      <MyPageContent />
+    </Suspense>
+  );
 };
 
 export default MyPage;

--- a/apps/client/src/app/mypage/page.tsx
+++ b/apps/client/src/app/mypage/page.tsx
@@ -1,11 +1,16 @@
 import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
 
 const Content = dynamic(() => import('@/components/MyPage/Content'), {
   ssr: false
 });
 
 const MyPage = () => {
-  return <Content />;
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Content />
+    </Suspense>
+  );
 };
 
 export default MyPage;

--- a/apps/client/src/app/mypage/page.tsx
+++ b/apps/client/src/app/mypage/page.tsx
@@ -1,22 +1,11 @@
-'use client';
-
 import dynamic from 'next/dynamic';
-import { useSearchParams } from 'next/navigation';
 
-// TODO: loading 컴포넌트
-const ProfileSetting = dynamic(() => import('@/components/MyPage/ProfileSetting'), { ssr: false });
-const QuizHistorySetting = dynamic(() => import('@/components/MyPage/QuizHistorySetting'), { ssr: false });
+const Content = dynamic(() => import('@/components/MyPage/Content'), {
+  ssr: false
+});
 
 const MyPage = () => {
-  const searchParams = useSearchParams();
-  const tab = searchParams.get('tab');
-
-  return (
-    <div className='w-full max-w-[81rem]'>
-      {tab === 'profile' && <ProfileSetting />}
-      {tab === 'my-quizzes' && <QuizHistorySetting />}
-    </div>
-  );
+  return <Content />;
 };
 
 export default MyPage;

--- a/apps/client/src/app/mypage/page.tsx
+++ b/apps/client/src/app/mypage/page.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import ProfileSetting from '@/components/MyPage/ProfileSetting';
-import QuizHistorySetting from '@/components/MyPage/QuizHistorySetting';
+import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
+
+// TODO: loading 컴포넌트
+const ProfileSetting = dynamic(() => import('@/components/MyPage/ProfileSetting'), { ssr: false });
+const QuizHistorySetting = dynamic(() => import('@/components/MyPage/QuizHistorySetting'), { ssr: false });
 
 const MyPage = () => {
   const searchParams = useSearchParams();

--- a/apps/client/src/components/Header.tsx
+++ b/apps/client/src/components/Header.tsx
@@ -116,7 +116,7 @@ const Header = () => {
                   <p className='font-semibold text-gray-900'>{user.name}님 안녕하세요</p>
                   <button
                     className='mt-2 px-4 py-1 text-sm font-medium text-gray-700 bg-gray-200 rounded-lg hover:bg-gray-100'
-                    onClick={() => router.push('/settings')}
+                    onClick={() => router.push('/mypage?tab=settings')}
                   >
                     내 정보 수정
                   </button>
@@ -124,7 +124,7 @@ const Header = () => {
                 <hr className='my-3 border-gray-300' />
                 <button
                   className='flex items-center gap-3 w-full px-4 py-2 font-medium text-[#4E5968] hover:bg-gray-100 hover:rounded-lg'
-                  onClick={() => router.push('/mypage')}
+                  onClick={() => router.push('/mypage?tab=my-quizzes')}
                 >
                   <TbBookmark />
                   내가 푼 퀴즈

--- a/apps/client/src/components/MyPage/Content.tsx
+++ b/apps/client/src/components/MyPage/Content.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import ProfileSetting from './ProfileSetting';
+import QuizHistorySetting from './QuizHistorySetting';
+
+const Content = () => {
+  const searchParams = useSearchParams();
+  const tab = searchParams.get('tab');
+
+  return (
+    <div className='w-full max-w-[81rem]'>
+      {tab === 'profile' && <ProfileSetting />}
+      {tab === 'my-quizzes' && <QuizHistorySetting />}
+    </div>
+  );
+};
+
+export default Content;

--- a/apps/client/src/components/MyPage/MyPageContent.tsx
+++ b/apps/client/src/components/MyPage/MyPageContent.tsx
@@ -4,16 +4,11 @@ import { useSearchParams } from 'next/navigation';
 import ProfileSetting from './ProfileSetting';
 import QuizHistorySetting from './QuizHistorySetting';
 
-const Content = () => {
+const MyPageContent = () => {
   const searchParams = useSearchParams();
   const tab = searchParams.get('tab');
 
-  return (
-    <div className='w-full max-w-[81rem]'>
-      {tab === 'profile' && <ProfileSetting />}
-      {tab === 'my-quizzes' && <QuizHistorySetting />}
-    </div>
-  );
+  return <div className='w-full max-w-[81rem]'>{tab === 'profile' ? <ProfileSetting /> : <QuizHistorySetting />}</div>;
 };
 
-export default Content;
+export default MyPageContent;

--- a/apps/client/src/components/MyPage/ProfileSetting.tsx
+++ b/apps/client/src/components/MyPage/ProfileSetting.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+const ProfileSetting = () => {
+  return (
+    <section className=''>
+      <h1>ProfileSetting</h1>
+    </section>
+  );
+};
+
+export default ProfileSetting;

--- a/apps/client/src/components/MyPage/QuizHistorySetting.tsx
+++ b/apps/client/src/components/MyPage/QuizHistorySetting.tsx
@@ -15,7 +15,8 @@ const QuizHistorySetting = () => {
     queryKey: ['history', user?.id],
     queryFn: getMyPageHistories,
     staleTime: 5 * 60 * 1000,
-    gcTime: 30 * 60 * 1000
+    gcTime: 30 * 60 * 1000,
+    enabled: !!user?.id
   });
 
   return (

--- a/apps/client/src/components/MyPage/QuizHistorySetting.tsx
+++ b/apps/client/src/components/MyPage/QuizHistorySetting.tsx
@@ -14,7 +14,8 @@ const QuizHistorySetting = () => {
   const { data } = useQuery({
     queryKey: ['history', user?.id],
     queryFn: getMyPageHistories,
-    staleTime: 5 * 60 * 1000
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000
   });
 
   return (

--- a/apps/client/src/components/MyPage/QuizHistorySetting.tsx
+++ b/apps/client/src/components/MyPage/QuizHistorySetting.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { getMyPageHistories } from '@/apis/mypage';
+import { useUserStore } from '@/providers/user-provider';
+import { useQuery } from '@tanstack/react-query';
+import classNames from 'classnames';
+import { useRouter } from 'next/navigation';
+
+const QuizHistorySetting = () => {
+  const router = useRouter();
+
+  const { user } = useUserStore((set) => set);
+
+  const { data } = useQuery({
+    queryKey: ['history', user?.id],
+    queryFn: getMyPageHistories,
+    staleTime: 5 * 60 * 1000
+  });
+
+  return (
+    <section className='w-full grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] p-4 gap-8'>
+      {data?.quizzes.map((quiz: any) => {
+        const progress = (quiz.results.correctResults / quiz.results.totalResults) * 100;
+        const levelColor = classNames({
+          'bg-orange-700': quiz.level === 3,
+          'bg-orange-500': quiz.level === 2,
+          'bg-orange-300': quiz.level === 1
+        });
+
+        return (
+          <div
+            key={quiz.id}
+            className='w-full flex flex-col justify-between gap-4 h-[190px] p-4 bg-gray-200 shadow-sm rounded-lg'
+          >
+            <p className='text-sm text-[#031228B3]'>{quiz.createdAt}</p>
+            <div className='flex items-center justify-between w-full'>
+              <div className='flex items-center gap-2'>
+                <p className='text-2xl font-bold'>{quiz.category}</p>
+                <p className='text-sm text-[#031228B3]'>{quiz.details}</p>
+              </div>
+              <span
+                className={`text-xs font-semibold text-white px-2 py-1 rounded-full whitespace-nowrap ${levelColor}`}
+              >
+                Level {quiz.level}
+              </span>
+            </div>
+            <div className='w-full'>
+              <div className='w-full bg-gray-300 rounded-full h-3 overflow-hidden'>
+                <div className='h-3 bg-green-500 transition-all duration-500' style={{ width: `${progress}%` }}></div>
+              </div>
+              <p className='text-xs text-[#031228B3] text-right mt-1'>
+                {quiz.results.correctResults} / {quiz.results.totalResults}
+              </p>
+            </div>
+            <button className='text-sm self-end' onClick={() => router.push(`/result/${quiz.id}`)}>
+              해설 확인
+            </button>
+          </div>
+        );
+      })}
+    </section>
+  );
+};
+
+export default QuizHistorySetting;

--- a/apps/client/src/components/MyPage/SideBar.tsx
+++ b/apps/client/src/components/MyPage/SideBar.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { sidebarItems } from '@/constants/sidebarItems';
+import classNames from 'classnames';
+import { useSearchParams, useRouter } from 'next/navigation';
+
+const SideBar = () => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const tab = searchParams.get('tab');
+
+  return (
+    <nav className='w-[300px] h-full px-5'>
+      <ul className='flex flex-col gap-4 p-4'>
+        {sidebarItems.map((item) => (
+          <li
+            key={item.id}
+            className={classNames(
+              'px-3 py-2 text-[#031228B3] font-medium rounded-lg hover:bg-green-100 transition-all cursor-pointer whitespace-nowrap',
+              tab === `${item.id}` && 'bg-green-100'
+            )}
+            onClick={() => router.push(`/mypage?tab=${item.id}`)}
+          >
+            {item.name}
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};
+
+export default SideBar;

--- a/apps/client/src/constants/sidebarItems.ts
+++ b/apps/client/src/constants/sidebarItems.ts
@@ -1,0 +1,4 @@
+export const sidebarItems = [
+  { id: 'profile', name: '내 정보' },
+  { id: 'my-quizzes', name: '내가 푼 퀴즈' }
+];

--- a/apps/client/src/types/mypage.type.ts
+++ b/apps/client/src/types/mypage.type.ts
@@ -1,0 +1,6 @@
+import { TQuiz } from './quiz.type';
+
+export type TMyPageHistories = {
+  userId: number;
+  quizzes: Omit<TQuiz, 'questions' | 'version'>[];
+};

--- a/apps/server/src/quiz/entities/quiz.entity.ts
+++ b/apps/server/src/quiz/entities/quiz.entity.ts
@@ -1,5 +1,6 @@
 import { BaseEntity } from 'src/common/entity/base.entity';
 import { QuestionEntity } from 'src/question/entities/question.entity';
+import { ResultEntity } from 'src/result/entities/result.entity';
 import { UserEntity } from 'src/user/entities/user.entity';
 import {
   Column,
@@ -30,4 +31,7 @@ export class QuizEntity extends BaseEntity {
     cascade: true,
   })
   questions: QuestionEntity[];
+
+  @OneToMany(() => ResultEntity, (result) => result.quiz)
+  results: ResultEntity[];
 }

--- a/apps/server/src/quiz/quiz.module.ts
+++ b/apps/server/src/quiz/quiz.module.ts
@@ -5,9 +5,13 @@ import { QuizController } from './quiz.controller';
 import { QuizService } from './quiz.service';
 import { QuestionModule } from 'src/question/question.module';
 import { UserEntity } from 'src/user/entities/user.entity';
+import { ResultEntity } from 'src/result/entities/result.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([QuizEntity, UserEntity]), QuestionModule],
+  imports: [
+    TypeOrmModule.forFeature([QuizEntity, UserEntity, ResultEntity]),
+    QuestionModule,
+  ],
   controllers: [QuizController],
   providers: [QuizService],
 })

--- a/apps/server/src/result/entities/result.entity.ts
+++ b/apps/server/src/result/entities/result.entity.ts
@@ -1,5 +1,6 @@
 import { BaseEntity } from 'src/common/entity/base.entity';
 import { QuestionEntity } from 'src/question/entities/question.entity';
+import { QuizEntity } from 'src/quiz/entities/quiz.entity';
 import { UserEntity } from 'src/user/entities/user.entity';
 import {
   Column,
@@ -36,4 +37,10 @@ export class ResultEntity extends BaseEntity {
 
   @ManyToOne(() => UserEntity, (user) => user.results)
   user: UserEntity;
+
+  @ManyToOne(() => QuizEntity, (quiz) => quiz.results, {
+    cascade: true,
+    nullable: false,
+  })
+  quiz: QuizEntity;
 }

--- a/apps/server/src/result/result.service.ts
+++ b/apps/server/src/result/result.service.ts
@@ -33,6 +33,10 @@ export class ResultService {
     createResultDto: CreateResultDto,
     userId: number,
   ) {
+    const quiz = await this.questionRepository.findOne({
+      where: { id: quizId },
+    });
+
     const questions = await this.questionRepository.find({
       where: { quiz: { id: quizId } },
     });
@@ -81,6 +85,7 @@ export class ResultService {
         correctAnswer: results.correctAnswer,
         description: results.description,
         user,
+        quiz,
       });
     }
 

--- a/apps/server/src/user/user.service.ts
+++ b/apps/server/src/user/user.service.ts
@@ -31,8 +31,8 @@ export class UserService {
 
     const histories = await this.userRepository.findOne({
       where: { id: user.sub },
-      relations: ['quizzes'],
-      order: { createdAt: 'DESC' },
+      relations: ['quizzes', 'quizzes.results'],
+      order: { quizzes: { id: 'DESC' } },
     });
 
     return {
@@ -43,6 +43,11 @@ export class UserService {
         details: quiz.details,
         createdAt: quiz.createdAt.toISOString().split('T')[0],
         level: quiz.level,
+        results: {
+          correctResults: quiz.results.filter((result) => result.isCorrect)
+            .length,
+          totalResults: quiz.results.length,
+        },
       })),
     };
   }


### PR DESCRIPTION
## ✅ 이슈 번호

close #33

<br>

## 🪄 작업 내용 (변경 사항)

### Client

- [x] 내가 푼 퀴즈 페이지 및 API 생성

### Server

- [x] `Quiz : Result = 1 : N` 연관관계 설정

<br>

## 📸 스크린샷

<img width="1470" alt="스크린샷 2025-03-06 오후 5 15 47" src="https://github.com/user-attachments/assets/a59c9e89-7153-4475-a378-dbf1995826c8" />

<br>

## 💡 설명

### Client

- `/mypage` 하위에 `layout.tsx`를 생성하여 해당 페이지의 공통 레이아웃을 정의하였습니다.

- 내가 푼 퀴즈를 불러오는 API는 클라이언트 컴포넌트에서 호출하도록 설정

  - 사용자 개별 퀴즈 기록은 SEO가 필요하지 않으므로 클라이언트 컴포넌트에서 `useQuery`를 사용하여 데이터를 불러오도록 하였습니다.

- staleTime과 gcTime
  - 사용자가 새로운 퀴즈를 풀지 않는 이상 기존 퀴즈 기록은 변하지 않으므로, `staleTime`을 5분으로 설정하여 불필요한 API가 호출되지 않도록 설정하였습니다.
  - `gcTime`을 30분으로 설정하여 사용자가 일정 시간 동안 여러 번 퀴즈 기록을 확인하더라도 불필요한 API 요청없이 캐시된 데이터를 유지하도록 설정하였습니다.

### Server

- `Quiz : Result = 1: N` 관계 설정
  - 사용자가 푼 퀴즈와 해당 퀴즈에 대한 개별 문제 풀이 결과를 조회할 수 있도록 추가 관계를 설정해주었습니다.

<br>

## 📍 트러블 슈팅

### `/mypage` prerender error 발생

- **원인**

  - `useSearchParams()`는 클라이언트 전용 훅으로, 서버에서 실행될 경우 **prerender** 오류가 발생할 수 있습니다.
  - Next.js는 기본적으로 페이지를 **정적으로 미리 렌더링**하려고 하지만, `useSearchParams()`는 라우트 변경 후 브라우저에서만 값을 사용할 수 있습니다.
  - 따라서 `app/mypage/page.tsx`에서 직접 `useSearchParams()`를 호출하면 서버에서 렌더링하려고 시도하면서 build시 오류가 발생합니다.

    ```typescript
    // 오류 발생 코드
    // app > mypage > page.tsx
    'use client';

    import ProfileSetting from '@/components/MyPage/ProfileSetting';
    import QuizHistorySetting from '@/components/MyPage/QuizHistorySetting';
    import { useSearchParams } from 'next/navigation';

    const MyPage = () => {
    const searchParams = useSearchParams();
    const tab = searchParams.get('tab');

    return (
            <div className='w-full max-w-[81rem]'>
            {tab === 'profile' && <ProfileSetting />}
            {tab === 'my-quizzes' && <QuizHistorySetting />}
            </div>
        );
    };

    export default MyPage;
    ```

  <br>

- **해결 방법 1️⃣**

  - `export const dynamic = 'force-dynamic';`를 추가하여 Next.js가 해당 페이지를 정적으로 미리 렌더링하지 않고 **항상 동적으로 렌더링**하도록 설정하였습니다.

    ```typescript
    import Content from '@/components/MyPage/Content';

    export const dynamic = 'force-dynamic';

    const MyPage = () => {
    return <Content />;
    };

    export default MyPage;
    ```

  - 항상 새로운 HTML을 생성하므로 `useSearchParams()`로 인한 prerender 오류를 해결할 수 있었습니다.
  - 하지만 `force-dynamic`을 사용하면 **매 요청마다 서버에서 새로운 데이터를 가져오므로** `staleTime`과 `gcTime`을 활용한 클라이언트 캐싱이 무의미해집니다.

  <br>

- **해결 방법 2️⃣**

  - 클라이언트에서 캐싱을 유지할 수 있는 `Suspense` 방식을 선택하였습니다.
  - `page.tsx`에서 `useSearchParams()`를 호출하는 코드를 별도의 컴포넌트로 분리하였습니다.
  - 별도로 분리한 컴포넌트를 `<Suspense>`로 감싸서 Next.js가 초기 렌더링 시 클라이언트 컴포넌트를 비동기적으로 불러오도록 하였습니다.

    ```typescript
    // components > MyPage > MyPageContent.tsx (별도의 컴포넌트로 분리)
    'use client';

    import { useSearchParams } from 'next/navigation';
    import ProfileSetting from './ProfileSetting';
    import QuizHistorySetting from './QuizHistorySetting';

    const MyPageContent = () => {
    const searchParams = useSearchParams();
    const tab = searchParams.get('tab');

    return <div className='w-full max-w-[81rem]'>{tab === 'profile' ? <ProfileSetting /> : <QuizHistorySetting />}</div>;
    };

    export default MyPageContent;
    ```

    ```typescript
    // app > mypage > page.tsx
    import MyPageContent from '@/components/MyPage/MyPageContent';
    import { Suspense } from 'react';

    const MyPage = () => {
    return (
        <Suspense>
             <MyPageContent />
        </Suspense>
    );
    };

    export default MyPage;
    ```

