### PR TITLE
[Client] 퀴즈 생성 후 /challenge 페이지 전환 시 깜빡임 문제 수정

### DIFF
--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { ExplanationVisibleStoreProvider } from '@/providers/explanationVisible-
 import { UserStoreProvider } from '@/providers/user-provider';
 import { Toaster } from 'react-hot-toast';
 import Footer from '@/components/Layout/Footer';
+import LayoutWrapper from '@/components/Layout/LayoutWrapper';
 
 export const metadata: Metadata = {
   title: 'QuiWe',
@@ -21,11 +22,7 @@ const pretendard = localFont({
   display: 'swap'
 });
 
-export default function RootLayout({
-  children
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang='en' className={`${pretendard.variable} font-pretendard`}>
       <body>
@@ -35,7 +32,9 @@ export default function RootLayout({
             <Header />
             <AnswerStoreProvider>
               <ResultStoreProvider>
-                <ExplanationVisibleStoreProvider>{children}</ExplanationVisibleStoreProvider>
+                <ExplanationVisibleStoreProvider>
+                  <LayoutWrapper>{children}</LayoutWrapper>
+                </ExplanationVisibleStoreProvider>
               </ResultStoreProvider>
             </AnswerStoreProvider>
           </UserStoreProvider>

--- a/apps/client/src/components/Layout/LayoutWrapper.tsx
+++ b/apps/client/src/components/Layout/LayoutWrapper.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { usePathname } from 'next/navigation';
+import { ReactNode } from 'react';
+
+export default function LayoutWrapper({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+
+  return (
+    <AnimatePresence mode='wait'>
+      <motion.div
+        key={pathname}
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/apps/client/src/components/Quiz/Category/SubmitButton.tsx
+++ b/apps/client/src/components/Quiz/Category/SubmitButton.tsx
@@ -1,18 +1,22 @@
 'use client';
 
 import { useCreateQuiz } from '@/hooks/useCreateQuiz';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import CustomLoading from '@/components/Layout/CustomLoading';
 import toast from 'react-hot-toast';
-import { CREATE_QUIZ_MESSAGES } from '@/constants/loadingMessage';
+import { CREATE_QUIZ_MESSAGES, LOADING_MESSAGE } from '@/constants/loadingMessage';
+import { useEffect, useState } from 'react';
 
 const SubmitButton = () => {
+  const router = useRouter();
+  const [isNavigating, setIsNavigating] = useState(false);
+
   const lastPath = usePathname().split('/').pop();
   const searchParams = useSearchParams();
   const detailsParams = searchParams.getAll('detail');
   const levelParams = searchParams.get('level');
 
-  const { mutate, isPending } = useCreateQuiz();
+  const { mutate, isPending, isSuccess, data } = useCreateQuiz();
 
   const handleClick = () => {
     if (!detailsParams || !levelParams || !lastPath) {
@@ -27,12 +31,27 @@ const SubmitButton = () => {
     });
   };
 
+  useEffect(() => {
+    if (isSuccess && data?.id) {
+      setIsNavigating(true);
+      router.replace(`/challenge/${data.id}`);
+    }
+  }, [isSuccess, data]);
+
+  if (isPending) {
+    return <CustomLoading messages={CREATE_QUIZ_MESSAGES} />;
+  }
+
+  if (isNavigating) {
+    return <CustomLoading messages={LOADING_MESSAGE} />;
+  }
+
   return (
     <button
       onClick={handleClick}
       className='w-full mt-6 p-3 text-md rounded-lg transition-all duration-300 bg-green-100 hover:bg-green-200'
     >
-      {isPending ? <CustomLoading messages={CREATE_QUIZ_MESSAGES} /> : '제출하고 퀴즈 풀러가기'}
+      제출하고 퀴즈 풀러가기
     </button>
   );
 };

--- a/apps/client/src/constants/loadingMessage.ts
+++ b/apps/client/src/constants/loadingMessage.ts
@@ -5,3 +5,5 @@ export const CREATE_QUIZ_MESSAGES = [
 ];
 
 export const CREATE_RESULT_MESSAGES = ['사용자 답안 분석 중...', 'AI가 해설 생성 중...', '거의 완료되었습니다!🥝'];
+
+export const LOADING_MESSAGE = ['거의 완료되었습니다!🥝'];

--- a/apps/client/src/hooks/useCreateQuiz.ts
+++ b/apps/client/src/hooks/useCreateQuiz.ts
@@ -1,12 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createQuiz } from '@/apis/quiz';
 import toast from 'react-hot-toast';
-import { useRouter } from 'next/navigation';
 import { TQuizRequest } from '@/types/quiz.type';
 
 export const useCreateQuiz = () => {
   const queryClient = useQueryClient();
-  const router = useRouter();
 
   return useMutation({
     mutationKey: ['quiz'],
@@ -20,8 +18,6 @@ export const useCreateQuiz = () => {
       queryClient.invalidateQueries({
         queryKey: ['challenge', quizData.id]
       });
-
-      router.replace(`/challenge/${quizData.id}`);
     },
     onError: () => {
       toast.error('퀴즈 생성에 실패했습니다. 다시 시도해주세요.');

--- a/apps/server/src/result/result.service.ts
+++ b/apps/server/src/result/result.service.ts
@@ -116,28 +116,29 @@ export class ResultService {
     correctAnswer: string;
   }> {
     const prompt = `
-    Question: ${title}
-    Options: ${options.join(', ')}
-
-    User's Answer: "${userAnswer}"
-
-    Evaluation Criteria:
-    1. Correctness Evaluation:
-      - Determine if the user's answer matches the correct option among the provided choices.
-      - Return 'true' if the user's answer is correct, or 'false' if it is incorrect.
-    2. Detailed Explanation:
-      - If the user's answer is correct, explain why it is the correct answer, focusing on the technical or logical reasons.
-      - If the user's answer is incorrect, clearly explain why it is wrong and provide guidance to help the user understand the correct choice.
-    3. Correct Answer:
-      - If the user's answer is incorrect, specify the correct answer clearly and explain why it is the most appropriate choice among the options.
-
-    Your output should strictly follow this JSON format:
-    {
-      "isCorrect": true or false,
-      "description": "Provide a detailed explanation in Korean. If the answer is correct, explain why it is correct. If incorrect, explain the mistake and provide constructive feedback.",
-      "correctAnswer": "Provide the correct answer in Korean and explain why it is the best choice."
-    }
-  `;
+      Evaluate the following multiple-choice question and provide the results in JSON format.
+  
+      Question: "${title}"
+      Options: ${options.join(', ')}
+  
+      User's Answer: "${userAnswer}"
+  
+      ### Key Instructions:
+      1. Evaluate whether the user's answer is correct based on the options provided.
+      2. Provide a detailed explanation in Korean, indicating why the answer is correct or incorrect.
+         - If correct, explain why the selected option is the correct one.
+         - If incorrect, explain the mistake and provide the correct answer.
+      3. Return the correct answer in Korean and explain why it is the best option.
+  
+      **Response Format (JSON)**
+      {
+        "isCorrect": true or false,
+        "description": "A detailed explanation in Korean based on the user's answer.",
+        "correctAnswer": "The correct answer in Korean with a detailed explanation."
+      }
+  
+      **STRICTLY RETURN JSON ONLY.**
+    `;
 
     const response = await this.openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
@@ -160,25 +161,27 @@ export class ResultService {
     correctAnswer: string;
   }> {
     const prompt = `
-    Evaluate the following answer to a question and provide the results in JSON format.
+      Evaluate the following question and provide the results in JSON format.
   
-    Question: "${title}"
+      Question: "${title}"
   
-    User's Answer: "${userAnswer}"
+      User's Answer: "${userAnswer}"
   
-    Evaluation Criteria:
-    1. Determine if the user's answer is correct ('True') or incorrect ('False') based on the question's requirements.
-    2. Provide a detailed explanation in Korean tailored to the user's answer:
-       - If the answer is correct, provide additional technical insights, examples, or related concepts to deepen the user's understanding.
-       - If the answer is incorrect, analyze the user's response to explain why it is incorrect. Offer constructive feedback on how to approach the question correctly and clarify the correct answer.
-    3. Include the correct or model answer in Korean for clarity.
+      ### Key Instructions:
+      1. Determine if the user's answer is correct ('True') or incorrect ('False') based on the question's requirements.
+      2. Provide a detailed explanation in Korean based on the user's answer.
+         - If the answer is correct, provide a detailed explanation of why it is correct.
+         - If the answer is incorrect, explain why it is wrong and provide constructive feedback on how to approach the question correctly.
+      3. Return the correct or model answer in Korean.
   
-    Your output should strictly follow this JSON format:
-    {
-      "isCorrect": true or false,
-      "description": "A detailed explanation in Korean based on the user's answer. Include technical insights or feedback depending on the correctness.",
-      "correctAnswer": "The correct answer in Korean or a detailed explanation of the concept related to the question."
-    }
+      **Response Format (JSON)**
+      {
+        "isCorrect": true or false,
+        "description": "A detailed explanation in Korean based on the user's answer.",
+        "correctAnswer": "The correct answer in Korean or a detailed explanation of the concept."
+      }
+  
+      **STRICTLY RETURN JSON ONLY.**
     `;
 
     const response = await this.openai.chat.completions.create({


### PR DESCRIPTION
## ✅ 이슈 번호

close #45

<br>

## 🪄 작업 내용 (변경 사항)

- [x] 퀴즈 생성 후 /challenge 페이지 전환 시 깜빡임 문제 수정
- [x] 페이지 전환 애니메이션 생성

<br>

## 📸 스크린샷

**📍 페이지 전환 애니메이션 생성**

![-framermotion-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/17aa1b5a-ed0c-48c4-8313-b5b0ad873fb5)

<br>

**📍 퀴즈 생성 후 /challenge 페이지 전환 시 깜빡임 문제 수정**

- 수정 전
  ![화면-기록-2025-04-09-오후-3 14 05](https://github.com/user-attachments/assets/f2b272ab-8063-4bd6-97c2-619e462fce06)

- 수정 후
  ![setTimeoutX--ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/826f5a6a-5ef4-4a3e-b930-15ce86454f1a)

<br>

## 💡 설명

#### 페이지 전환 시 깜빡임 문제 해결

- 기존에는 `useMutation`의 `onSuccess` 내부에서 `router.replace()`를 직접 호출했습니다.
  - 이 경우, `isPending === false`가 되는 순간 `SubmitButton` 컴포넌트는 다시 버튼 UI를 렌더링하게 되고,  
    아직 라우팅이 완료되지 않았기 때문에 기존 페이지(`/quiz/Python?detail=set&level=1`)가 잠깐 화면에 다시 보이는 현상이 발생했습니다.
  - 즉, 데이터 요청이 완료된 이후 페이지가 전환되기 전까지의 짧은 시간 동안 이전 화면이 깜빡이는 UX 문제가 있었습니다.
- 이를 해결하기 위해 다음과 같이 수정하였습니다.

  1. `router.replace()` 호출을 `onSuccess` 내부가 아닌 `useEffect`로 분리하여 렌더링 이후에 실행되도록 처리
  2. 라우터 전환 상태를 나타내는 `isNavigating` 상태를 선언하여 `isPending === false` 이후에도 로딩 화면 유지
  3. 실제 라우팅이 완료되기 전까지 기존 페이지 UI를 보여주지 않고 `<CustomLoading />`만 노출되도록 수정

<br>

#### 페이지 전환 애니메이션 추가

- `LayoutWrapper`를 생성하여 `motion.div`로 감싸고, `usePathname()`을 key로 사용하여 경로 변경 시 페이지 전환 애니메이션이 작동하도록 구현했습니다.

<br>

## 📍 트러블 슈팅
