### PR TITLE
[Server] 카카오 로그아웃 오류 해결

### DIFF
--- a/apps/server/src/oauth/oauth.service.ts
+++ b/apps/server/src/oauth/oauth.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
-import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import axios from 'axios';
 import { Response } from 'express';
@@ -11,7 +10,6 @@ import { Repository } from 'typeorm';
 @Injectable()
 export class OauthService {
   constructor(
-    private readonly jwtService: JwtService,
     private readonly authService: AuthService,
     @InjectRepository(UserEntity)
     private readonly userRepository: Repository<UserEntity>,
@@ -19,19 +17,15 @@ export class OauthService {
 
   async kakaoLogin(code: string, res: Response) {
     try {
-      const tokenResponse = await axios.post(
-        'https://kauth.kakao.com/oauth/token',
-        {
-          grant_type: 'authorization_code',
-          client_id: process.env.KAKAO_ID,
-          client_secret: process.env.KAKAO_SECRET,
-          redirect_uri: process.env.KAKAO_CALLBACK_URI,
-          code: code,
-        },
-        { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
-      );
+      const tokenResponse = await this.requestKakaoToken('authorization_code', {
+        redirect_uri: process.env.KAKAO_CALLBACK_URI!,
+        code,
+      });
 
-      const kakaoAccessToken = tokenResponse.data.access_token;
+      const {
+        access_token: kakaoAccessToken,
+        refresh_token: kakaoRefreshToken,
+      } = tokenResponse;
 
       const kakaoUserResponse = await axios.get(
         'https://kapi.kakao.com/v2/user/me',
@@ -57,10 +51,14 @@ export class OauthService {
           profileImage: kakaoUser.properties.profile_image,
           refreshToken: '',
           kakaoAccessToken,
+          kakaoRefreshToken,
         });
         user = await this.userRepository.save(user);
       } else {
-        await this.userRepository.update(user.id, { kakaoAccessToken });
+        await this.userRepository.update(user.id, {
+          kakaoAccessToken,
+          kakaoRefreshToken,
+        });
       }
 
       await this.authService.generateTokensAndSetCookies(user, res);
@@ -73,38 +71,103 @@ export class OauthService {
   }
 
   async kakaoLogout(req: { user: JwtPayload }, res: Response) {
-    try {
-      const user = await this.userRepository.findOne({
-        where: {
-          id: req.user.sub,
-        },
-      });
-      if (!user || !user.kakaoAccessToken) {
-        return res.status(400).json({
-          message: '로그인 상태가 아닙니다.',
-        });
-      }
+    const user = await this.userRepository.findOne({
+      where: { id: req.user.sub },
+    });
+    if (!user || !user.kakaoAccessToken) {
+      return res.status(400).json({ message: '로그인 상태가 아닙니다.' });
+    }
 
+    let accessToken = user.kakaoAccessToken;
+
+    const logoutSuccess = await this.tryLogout(accessToken);
+    if (!logoutSuccess && user.kakaoRefreshToken) {
+      try {
+        const tokenData = await this.requestKakaoToken('refresh_token', {
+          refresh_token: user.kakaoRefreshToken,
+        });
+
+        accessToken = tokenData.access_token;
+
+        await this.userRepository.update(user.id, {
+          kakaoAccessToken: accessToken,
+          ...(tokenData.refresh_token && {
+            kakaoRefreshToken: tokenData.refresh_token,
+          }),
+        });
+
+        await this.tryLogout(accessToken);
+      } catch (err) {
+        return res
+          .status(500)
+          .json({ message: '카카오 access token 재발급 실패' });
+      }
+    } else if (!logoutSuccess) {
+      return res.status(500).json({ message: '카카오 로그아웃 실패' });
+    }
+
+    await this.userRepository.update(user.id, {
+      kakaoAccessToken: '',
+      kakaoRefreshToken: '',
+      refreshToken: '',
+    });
+
+    res.clearCookie('accessToken', { httpOnly: true });
+    res.clearCookie('refreshToken', { httpOnly: true });
+
+    return res.status(200).json({ message: '카카오 로그아웃 성공' });
+  }
+
+  private async tryLogout(accessToken: string): Promise<boolean> {
+    try {
       await axios.post('https://kapi.kakao.com/v1/user/logout', null, {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
-          Authorization: `Bearer ${user.kakaoAccessToken}`,
+          Authorization: `Bearer ${accessToken}`,
         },
       });
-
-      await this.userRepository.update(user.id, { kakaoAccessToken: '' });
-
-      res.clearCookie('accessToken', { httpOnly: true });
-      res.clearCookie('refreshToken', { httpOnly: true });
-
-      return res.status(200).json({
-        message: '카카오 로그아웃 성공',
-      });
+      return true;
     } catch (error) {
-      return res.status(500).json({
-        message: '카카오 로그아웃 처리 중 오류 발생',
-        error: error.response.data,
+      const code = error.response.data.code;
+      const status = error.response.status;
+      const isExpired = code === -401 || status === 401;
+
+      if (!isExpired) {
+        console.error(
+          '카카오 로그아웃 실패: ',
+          error.response.data || error.message,
+        );
+      }
+
+      return false;
+    }
+  }
+
+  private async requestKakaoToken(
+    grantType: 'authorization_code' | 'refresh_token',
+    payload: Record<string, string>,
+  ) {
+    try {
+      const params = new URLSearchParams({
+        grant_type: grantType,
+        client_id: process.env.KAKAO_ID!,
+        client_secret: process.env.KAKAO_SECRET!,
+        ...payload,
       });
+
+      const response = await axios.post(
+        'https://kauth.kakao.com/oauth/token',
+        params,
+        { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+      );
+
+      return response.data;
+    } catch (error) {
+      console.error(
+        '카카오 토큰 요청 실패: ',
+        error.response.data || error.message,
+      );
+      throw new InternalServerErrorException('카카오 토큰 요청 실패');
     }
   }
 }

--- a/apps/server/src/user/entities/user.entity.ts
+++ b/apps/server/src/user/entities/user.entity.ts
@@ -34,6 +34,10 @@ export class UserEntity extends BaseEntity {
   @Exclude()
   kakaoAccessToken: string;
 
+  @Column()
+  @Exclude()
+  kakaoRefreshToken: string;
+
   @OneToOne(() => PortfolioEntity)
   @JoinColumn() // 1:1 관계에선 필수
   portfolio: PortfolioEntity;


### PR DESCRIPTION
## ✅ 이슈 번호

close #47

<br>

## 🪄 작업 내용 (변경 사항)

- [x] 카카오 로그아웃 시 발생하는 `-401` 오류 해결
- [x] 카카오 토큰 요청 로직 `requestKakaoToken()`으로 함수 분리
- [x] kakao access token 만료 시, kakao refresh token을 통해 재발급 후 재요청

<br>

## 📸 스크린샷

<br>

## 💡 설명

### 문제 상황

![ezgif com-video-to-gif-converter (1)](https://github.com/user-attachments/assets/f2170920-550f-4717-be57-3eb1597aa9b5)

```json
{
    "message": "카카오 로그아웃 처리 중 오류 발생",
    "error": {
        "msg": "this access token does not exist",
        "code": -401
    }
}

-401: 유효하지 않은 앱키나 액세스 토큰으로 요청한 경우, 등록된 앱 정보와 호출된 앱 정보가 불일치 하는 경우
```

1. 사용자가 로그인한 상태에서 로그아웃 하지 않고 서버 종료
2. 서버 재시작 후, 브라우저의 쿠키가 유지되고 있어서 사용자는 여전히 로그인된 것처럼 동작
3. 이 상태에서 클라이언트가 카카오 로그아웃 요청을 보냄
4. 서버는 DB에 이전에 저장된 `kakao access token`을 꺼내 카카오에 로그아웃 요청을 보냄
5. 하지만 해당 `kakao access token`은 **이미 만료되어 카카오 서버에 존재하지 않는 토큰**
6. 즉, DB에 저장된 `kakao access token`과 카카오 서버의 세션 상태가 불일치하게 되어 로그아웃 요청이 실패

<br>

### 해결 방법

1. **`requestKakaoToken()` 함수 분리**
   - `kakao access token` 발급 및 재발급 요청을 담당하는 공통 함수
   - `grant_type: authorization_code | refresh_token`을 매개변수로 받아서 로그인과 토큰 재발급 모두 처리 가능하도록 개선
2. **`tryLogout()` 함수 생성**
   - 요청 실패 시 카카오 응답의 `code === -401` 또는 `status === 401`을 감지하여 토큰 만료 여부 판단
3. **로그아웃 시 `kakao access token` 만료 처리**
   - 1차 로그아웃 시도가 실패하게 된다면, `kakao refresh token`이 존재하는 경우 `kakao access token` 재발급
   - 재발급한 `kakao access token`으로 로그아웃 재시도
   - 최종적으로 DB에 저장된 `kakao access token`, `kakao refresh token`, `jwt refresh token`을 모두 제거하고 쿠키 또한 삭제

<div align="center">
    <img width="366" alt="로그아웃 했을 경우" src="https://github.com/user-attachments/assets/f928721a-fcda-4548-901a-6b862ec8b1eb" />
      <figcaption>로그아웃이 성공적으로 진행됐을 때 DB</figcaption>
</div>

<br>

## 📍 트러블 슈팅
